### PR TITLE
Setup conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ The repository is based on the [example Jupyter app](https://github.com/OSC/bc_e
 This Batch Connect app requires the following software be installed in a location accessible to the compute nodes that will run the tasks:
 
 - [Spack](https://spack.io/)
-  - A Spack environment containing `py-jupyterlab` and any other spack packages containing Python modules that are desired.
-  - The `spack.yaml` file from an environment configured for this app is included in this repo at `spack-environment/jupyter/spack.yml`.
+  - A Spack environment containing `miniconda3` (or equivalent) and any other spack packages that are required.
+  - The `spack.yaml` file from an environment configured for this app is included in this repo at `spack-environment/conda/spack.yml`.
+- [Conda](https://docs.anaconda.com/miniconda/)
+  - A conda environment containing `jupyterlab` and any required python packages.
 
-The default location for spack and the default environment name are defined in `form.yml`.
+The default location for the spack installation, spack environment, and conda environment are defined in `form.yml`
 
 ## Optional Additions
 
@@ -22,7 +24,7 @@ The app is set up to allow the use of different spack install locations and diff
 
 This repository should be added to the OnDemand app configuration. By default, this can be found at /var/www/ood/apps/sys.
 
-## Environment install script
+## Spack environment install script
 
 The spack install process can take a long time, which is problematic when trying to maintain a terminal session. To assist, this repo includes a script to use with `sbatch` to install dependencies as a slurm job. The script is set up for use with the default global spack installation, but can be modified to activate whatever environment is desired.
 
@@ -32,3 +34,12 @@ With this script, the install process looks like this:
 - Run the `installSpackEnvironment.sh` script as an sbatch script to install the dependencies asynchronously
 - Check on the progress of the job by tailing the log file or just seeing if the job is still running with `squeue`
 - When the job finishes, verify that packages are present with `spack find` and check for errors in the log output files.
+
+## Conda environment install script
+
+The conda environemnt install process can also take some time, so a similar approach is recommended. At a minimum, the following needs to be run:
+
+```
+spack env activate -p conda
+conda env create --file conda-environment/jupyter/environment.yml
+```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This Batch Connect app requires the following software be installed in a locatio
   - The `spack.yaml` file from an environment configured for this app is included in this repo at `spack-environment/conda/spack.yml`.
 - [Conda](https://docs.anaconda.com/miniconda/)
   - A conda environment containing `jupyterlab` and any required python packages.
+  - The `environment.yml` file from a minimal jupyter environment is configured in this repo at `conda-environment/jupyter/environment.yml`.
 
 The default location for the spack installation, spack environment, and conda environment are defined in `form.yml`
 
@@ -23,6 +24,16 @@ The app is set up to allow the use of different spack install locations and diff
 ## Install
 
 This repository should be added to the OnDemand app configuration. By default, this can be found at /var/www/ood/apps/sys.
+
+Additionally, the spack and conda environments need to be installed:
+
+```
+$ JID=$(sbatch --mem=16g -c 8 installSpackEnvironment.sh conda)
+
+$ sbatch --dependency=afterok:$JID --mem=16g -c 8 installCondaEnvironment.sh jupyter
+```
+
+For more details on the spack and conda environment install scripts, keep reading.
 
 ## Spack environment install script
 
@@ -37,9 +48,17 @@ With this script, the install process looks like this:
 
 ## Conda environment install script
 
-The conda environemnt install process can also take some time, so a similar approach is recommended. At a minimum, the following needs to be run:
+The conda environment install process can also take some time, so a similar approach is recommended. The assumption is that all conda environments will share the same `conda` spack environment, although this is not strictly required.
+
+To install the conda environment manually:
 
 ```
 spack env activate -p conda
 conda env create --file conda-environment/jupyter/environment.yml
+```
+
+Or run the utility script (preferably with `sbatch`):
+
+```
+./installCondaEnvironment.sh cs109a
 ```

--- a/conda-environment/cs109a/environment.yml
+++ b/conda-environment/cs109a/environment.yml
@@ -1,0 +1,27 @@
+name: cs109a
+
+channels:
+- conda-forge
+
+dependencies:
+# - asyncio # comes with python standard library
+- aiohttp
+- beautifulsoup4
+- jupyterlab
+- lxml
+- matplotlib
+- networkx
+- numpy
+- pandas
+- pillow
+- pip
+- python>=3.10
+- requests
+- scipy
+- scikit-learn
+- seaborn
+- selenium
+- statsmodels
+- pip:
+  - nbopen
+  - otter-grader

--- a/conda-environment/jupyter/environment.yml
+++ b/conda-environment/jupyter/environment.yml
@@ -1,0 +1,14 @@
+name: jupyter
+
+channels:
+- conda-forge
+
+dependencies:
+- jupyterlab
+- numpy
+- pandas
+- matplotlib
+- scipy
+- pip
+- python>=3.10
+- requests

--- a/form.yml
+++ b/form.yml
@@ -27,15 +27,21 @@ attributes:
   #     modules: "python/3.5 cuda/8.0.44"
   environment:
     label: "Spack environment"
-    value: "jupyter"
+    value: "conda"
     required: true
-    help: "Spack environment to use to load jupyter. This environment must include `py-jupyterlab` and exist in the spack install location specified. The default value for a generic configuration is \"jupyter\""
+    help: "Spack environment to use to load conda. The default is \"conda\". This spack environment must include \"miniconda3\" or equivalent."
   
   spack:
     label: "Spack installation location"
     value: "/shared/spack"
     required: true
     help: "The location of a spack installation folder to use. The default location is \"/shared/spack\". If using a custom location, use the absolute path to the root spack folder, containing `bin`, `etc`, `lib`, `opt`, `share`, and `var` folders."
+
+  conda:
+    label: "Conda environment"
+    value: "jupyter"
+    required: true
+    help: "The conda environment to use. The default is \"jupyter\". The conda environment must include \"jupyterlab\"."
 
   custom_num_cores:
     widget: "number_field"
@@ -61,6 +67,7 @@ attributes:
 form:
   - environment
   - spack
+  - conda
   - extra_jupyter_args
   - bc_num_hours
   - custom_num_cores

--- a/installCondaEnvironment.sh
+++ b/installCondaEnvironment.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Install packages in a conda environment given in the first argument
+
+# Activate spack
+. /shared/spack/share/spack/setup-env.sh
+
+# Activate conda environment
+spack env activate conda
+
+# Create conda environment and install python packages
+conda env create --file conda-environment/$1/environment.yml

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 ---
-name: Jupyter Notebook (spack)
+name: Jupyter Notebook (spack+conda)
 category: Interactive Apps
 subcategory: Servers
 role: batch_connect

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 ---
-name: Jupyter Notebook (spack+conda)
+name: Jupyter Notebook (conda)
 category: Interactive Apps
 subcategory: Servers
 role: batch_connect

--- a/spack-environment/conda/spack.yml
+++ b/spack-environment/conda/spack.yml
@@ -5,7 +5,7 @@
 spack:
   # add package specs to the `specs` list
   specs:
-  - micromamba
+  - miniconda3
   view: true
   concretizer:
     unify: true

--- a/spack-environment/conda/spack.yml
+++ b/spack-environment/conda/spack.yml
@@ -5,11 +5,7 @@
 spack:
   # add package specs to the `specs` list
   specs:
-  - py-jupyterlab
-  - py-numpy
-  - py-pandas
-  - py-matplotlib
-  - py-scipy
+  - micromamba
   view: true
   concretizer:
     unify: true

--- a/spack-environment/cs109a/spack.yml
+++ b/spack-environment/cs109a/spack.yml
@@ -8,7 +8,7 @@ spack:
   - miniconda3
   - git
   - lazygit
-  - zsh
+  # - zsh
   - neovim
   - tmux
   - cowsay

--- a/spack-environment/cs109a/spack.yml
+++ b/spack-environment/cs109a/spack.yml
@@ -1,0 +1,18 @@
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+spack:
+  # add package specs to the `specs` list
+  specs:
+  - miniconda3
+  - git
+  - lazygit
+  - zsh
+  - neovim
+  - tmux
+  - cowsay
+  - figlet
+  view: true
+  concretizer:
+    unify: true

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -31,6 +31,10 @@ spack find
 # Benchmark info
 echo "TIMING - Starting jupyter at: $(date)"
 
+# Activate conda environment
+eval "$(command conda 'shell.bash' 'hook' 2> /dev/null)"
+conda activate <%= context.conda %>
+
 # Launch the Jupyter Lab Server
 set -x
 jupyter lab --config="${CONFIG_FILE}" <%= context.extra_jupyter_args %>


### PR DESCRIPTION
This PR builds on [ood-jupyterlab-spack@56a2157](https://github.com/Harvard-ATG/ood-jupyterlab-spack/tree/56a21570e0a29d45c511422afb0f77c1648346cf) so that JupyterLab and any required python dependencies can be installed and managed with conda. This would be considered an intermediate approach between spack and apptainer jupyter apps. The end goal is to provide a way for courses to more fully manage their python environment with tools they already know. This PR doesn't quite achieve that, but it makes it possible, and in the short term we can accept conda environment files from courses such as cs109a and set them up with minimal changes. The role of spack in this context is to bootstrap the environment with [miniconda](https://docs.anaconda.com/miniconda/) and install any other system dependencies that are required. 

### Changes

- Updated `spack-environment` folder:
     - `spack-environment/conda/spack.yaml` is the default environment that installs `miniconda3`.
     - `spack-environment/cs109a/spack.yaml` is a custom environment for CS109a that installs `miniconda3` as well as some additional system dependencies.
- Created a `conda-environment` folder to hold [conda environment files](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html).
    - `conda-environments/jupyter/enivornment.yml` is the default JupyterLab environment with some standard python packages.
    - `conda-environment/cs109a/environment.yml` is a custom environment provided by CS109a.
- Updated README to describe the installation process. The spack environment needs to be setup first and then the conda environments can be setup.
- Added `installCondaEnvironment.sh` to handle the conda environment installation.

### Proposed usage

The `ood-jupyterlab-spack-conda` application can be used as-is (assuming the default spack and conda environments are setup), but it requires users to specify the conda environment name if it's anything other than the default. While that's OK, it may be better to customize the configuration to create a more user-friendly experience.

We could instead use this configuration as a template and adapt it to specific courses by deploying a copy and updating  `manifest.yml` and `form.yml` as appropriate. This would mean hard-coding the form attributes to point to the correct spack and conda environments. For CS109a, the `form.yml` would look like this:

```yml
attributes:
  environment: "cs109a"
  spack: "/shared/spack"
  conda: "cs109a"
```

This configuration means we are managing the conda environment for the course in the global spack installation. If that's the case, I would recommend an immutable approach to conda environments, which means we never update an environment, but instead create new versions and update the `form.yml` to point to the new environment. This approach is easier to manage when users are not able to edit the attributes.