### PR TITLE
Add config files for gpu-enabled app

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This Batch Connect app requires the following software be installed in a locatio
 
 The default location for the spack installation, spack environment, and conda environment are defined in `form.yml`
 
-## Optional Additions
+## User-Controlled Environments
 
-The app is set up to allow the use of different spack install locations and different environment names. That means that if a user has set up their own spack installation, or if a different configuration has been created for their use, that user can change their launch configuration from the app form and use different Python libraries in the same interface.
+The app is set up to allow the use of a user-controlled Python environment, referred to as the "course" environment. This "course" environment uses a global spack install, but is set to use a conda environment created with the `--prefix` option. In our `script.sh.erb`, the path to this environment is determined by the course ID, so other applications will require changing the path to the environment. In our application, we use this to provide the option for course instructors to manage an environment from a shared folder for a course, while still having a Python environment maintained by system administrators as a fallback. If this behavior is not desired, the form can be modified to hard-code a global installation.
 
 ## Install
 

--- a/conda-environment/bst236/environment.yml
+++ b/conda-environment/bst236/environment.yml
@@ -1,0 +1,15 @@
+name: bst236
+
+channels:
+- conda-forge
+
+dependencies:
+- jupyterlab
+- numpy
+- pandas
+- matplotlib
+- scipy
+- pip
+- python>=3.10
+- requests
+- pytorch

--- a/conda-environment/cs109b/environment.yml
+++ b/conda-environment/cs109b/environment.yml
@@ -1,0 +1,38 @@
+name: cs109b
+
+channels:
+    - conda-forge
+
+dependencies:
+    - arviz==0.17.0
+    - beautifulsoup4==4.12.3
+    - imageio==2.33.1
+    - ipython==8.20.0
+    - jupyterlab==4.0.11
+    - matplotlib==3.8.2
+    - nltk==3.8.1
+    - numpy==1.26.3
+    - pandas==2.2.0
+    - pillow==10.2.0
+    - pip==23.3.2
+    - plotly==5.18.0
+    - python==3.11.7
+    - pymc==5.10.3
+    - requests==2.31.0
+    - scikit-learn==1.4.0
+    - scipy==1.12.0
+    - seaborn==0.13.1
+    - statsmodels==0.14.1
+    - tensorflow==2.15.0
+    - pytorch==2.1.0
+    - tqdm==4.66.1
+    - transformers==4.37.0
+
+    - pip:
+      - gap-stat==2.0.3
+      - nbopen==0.7
+      - otter-grader==5.2.3
+      - tensorflow_addons==0.23.0
+      - tensorflow_datasets==4.9.4
+      - tensorflow_hub==0.16.0
+      - tf_keras_vis==0.8.6

--- a/form.yml
+++ b/form.yml
@@ -49,7 +49,9 @@ attributes:
     value: 1
     min: 1
     max: 4
-    step: 1
+    step: 
+  
+  custom_num_gpus: 0
 
   # Any extra command line arguments to feed to the `jupyter notebook ...`
   # command that launches the Jupyter notebook within the batch job

--- a/local/bst236.yml.erb
+++ b/local/bst236.yml.erb
@@ -23,7 +23,7 @@ else
     # Cannot have other enabled groups if a course installation is in use
     # This is because the course installation uses the course shared folder,
     # which is not accessible to users outside of that course.
-    "150579" # COMPSCI 1090B: Data Science 2: Advanced Topics in Data Science
+    "150579" # BST 236: Computing I
   ]
 
   # Check if the groups that the user is in match any of the courses that should

--- a/local/bst236.yml.erb
+++ b/local/bst236.yml.erb
@@ -23,7 +23,7 @@ else
     # Cannot have other enabled groups if a course installation is in use
     # This is because the course installation uses the course shared folder,
     # which is not accessible to users outside of that course.
-    "142601" # COMPSCI 1090B: Data Science 2: Advanced Topics in Data Science
+    "150579" # COMPSCI 1090B: Data Science 2: Advanced Topics in Data Science
   ]
 
   # Check if the groups that the user is in match any of the courses that should
@@ -42,15 +42,15 @@ end
 # under /etc/ood/config/clusters.d/*.yml
 cluster: "<%= cluster %>"
 
-title: "Jupyter Lab - CS 1090b (GPU)"
+title: "Jupyter Lab - BST 236 (GPU)"
 description: |
-  This app is configured for GPU access for CS 1090b.
+  This app is configured for GPU access for BST 236.
 
   This app will launch a Jupyter Notebook server on one or more nodes. This
   configuration uses [Spack](https://spack.io/) to load a
   [Conda](https://anaconda.org/anaconda/conda) environment using
   [Miniconda](https://docs.anaconda.com/miniconda/) to load Jupyter Lab, and
-  was built for the course CS 1090b (and its cross-listed courses).<br/><br/>The
+  was built for the course BST 236.<br/><br/>The
   app launches outside of a container, so it has access to slurm commands, but
   since the app is running as a slurm job, the `srun` command will use the
   resources of the current job, rather than starting a new job. That is, unless
@@ -63,9 +63,9 @@ cacheable: false
 # Define attribute values that aren't meant to be modified by the user within
 # the Dashboard form
 attributes:
-  course: "142601"
+  course: "150579"
   spack: "conda"
-  conda: "cs109b"
+  conda: "bst236"
   bc_queue: "gpu"
   environment:
     widget: "radio_button"

--- a/local/cs1090a.yml.erb
+++ b/local/cs1090a.yml.erb
@@ -8,7 +8,8 @@ enabledGroups = [
   # Cannot have other enabled groups if a course installation is in use
   # This is because the course installation uses the course shared folder, 
   # which is not accessible to users outside of that course.
-  "137799"  # COMPSCI 1090A: Data Science 1: Introduction to Data Science
+  "137799", # COMPSCI 1090A: Data Science 1: Introduction to Data Science
+  "142601"  # COMPSCI 1090B: Data Science 2: Advanced Topics in Data Science
 ]
 
 def arrays_have_common_element(array1, array2)

--- a/local/cs1090b.yml.erb
+++ b/local/cs1090b.yml.erb
@@ -8,7 +8,7 @@ enabledGroups = [
   # Cannot have other enabled groups if a course installation is in use
   # This is because the course installation uses the course shared folder,
   # which is not accessible to users outside of that course.
-  "137799",  # COMPSCI 1090A: Data Science 1: Introduction to Data Science
+  # "137799",  # COMPSCI 1090A: Data Science 1: Introduction to Data Science
   "135510"
 ]
 
@@ -70,18 +70,19 @@ attributes:
   #    - ["Course (course managed)", "course"]
   #    - ["Global (system managed)", "global"]
 
-  custom_num_cores:
-    widget: "number_field"
-    label: "Number of CPUs"
-    value: 1
-    min: 1
-    max: 4
-    step: 1
+  custom_num_cores: 8
+  # custom_num_cores:
+  #   widget: "number_field"
+  #   label: "Number of CPUs"
+  #   value: 1
+  #   min: 1
+  #   max: 4
+  #   step: 1
 
   bc_num_hours:
     value: 2
     min: 1
-    max: 168  # 7 days max
+    max: 6  # 6 hours max
     step: 1
 
   # Any extra command line arguments to feed to the `jupyter notebook ...`

--- a/local/cs1090b.yml.erb
+++ b/local/cs1090b.yml.erb
@@ -3,47 +3,54 @@
 # @note Used to define the submitted cluster, title, description, and
 #   hard-coded/user-defined attributes that make up this Batch Connect app.
 <%-
-userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name).flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
-enabledGroups = [
-  # Cannot have other enabled groups if a course installation is in use
-  # This is because the course installation uses the course shared folder,
-  # which is not accessible to users outside of that course.
-  # "137799",  # COMPSCI 1090A: Data Science 1: Introduction to Data Science
-  "135510"
-]
-
 def arrays_have_common_element(array1, array2)
   # Use the `&` operator to get the intersection of the two arrays
   # If the intersection is not empty, return true, otherwise false
   !(array1 & array2).empty?
 end
 
-# Check if the groups that the user is in match any of the courses that should
-# have access to this app.
-
-if arrays_have_common_element(userGroups, enabledGroups)
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name)
+# First check if the user is in an admin group
+adminGroups = [
+  "ondemand-admins-1025174" # HUIT OOD admin group, prod environment
+]
+if arrays_have_common_element(userGroups, adminGroups)
   cluster="*"
 else
-  cluster="disable_this_app"
+  # If the user is not in an admin group, check if they're in an authorized Canvas group
+  userCanvasGroups = userGroups.flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+  enabledGroups = [
+    # Cannot have other enabled groups if a course installation is in use
+    # This is because the course installation uses the course shared folder,
+    # which is not accessible to users outside of that course.
+    "142601" # COMPSCI 1090B: Data Science 2: Advanced Topics in Data Science
+  ]
+
+  # Check if the groups that the user is in match any of the courses that should
+  # have access to this app.
+
+  if arrays_have_common_element(userGroups, enabledGroups)
+    cluster="*"
+  else
+    cluster="disable_this_app"
+  end
 end
 -%>
 ---
 
 # **MUST** set cluster id here that matches cluster configuration file located
 # under /etc/ood/config/clusters.d/*.yml
-# @example Use the Owens cluster at Ohio Supercomputer Center
-#     cluster: "owens"
 cluster: "<%= cluster %>"
 
 title: "Jupyter Lab - CS 1090b"
 description: |
-  This app is configured for GPU testing for CS 1090b, CS 2050, and BST 236.
+  This app is configured for GPU access for CS 1090b.
 
   This app will launch a Jupyter Notebook server on one or more nodes. This
   configuration uses [Spack](https://spack.io/) to load a
   [Conda](https://anaconda.org/anaconda/conda) environment using
   [Miniconda](https://docs.anaconda.com/miniconda/) to load Jupyter Lab, and
-  was built for the course CS 1090a (and its cross-listed courses).<br/><br/>The
+  was built for the course CS 1090b (and its cross-listed courses).<br/><br/>The
   app launches outside of a container, so it has access to slurm commands, but
   since the app is running as a slurm job, the `srun` command will use the
   resources of the current job, rather than starting a new job. That is, unless
@@ -56,23 +63,24 @@ cacheable: false
 # Define attribute values that aren't meant to be modified by the user within
 # the Dashboard form
 attributes:
-  course: "135510"
+  course: "142601"
   spack: "conda"
   conda: "cs109b"
   bc_queue: "gpu"
-  environment: "global"
-  #  widget: "radio_button"
-  #  value: "course"
-  #  help: |
-  #    Choose the environment used to launch Jupyter Lab. The "Course"
-  #    environment is managed by the teaching staff and has the latest
-  #    dependencies, while the "Global" environment is managed at the system
-  #    level and provides the initial set of dependencies.
-  #  options:
-  #    - ["Course (course managed)", "course"]
-  #    - ["Global (system managed)", "global"]
+  environment:
+    widget: "radio_button"
+    value: "course"
+    help: |
+      Choose the environment used to launch Jupyter Lab. The "Course"
+      environment is managed by the teaching staff and has the latest
+      dependencies, while the "Global" environment is managed at the system
+      level and provides the initial set of dependencies.
+    options:
+      - ["Course (course managed)", "course"]
+      - ["Global (system managed)", "global"]
 
   custom_num_cores: 8
+  custom_num_gpus: 1
   # custom_num_cores:
   #   widget: "number_field"
   #   label: "Number of CPUs"

--- a/local/cs1090b.yml.erb
+++ b/local/cs1090b.yml.erb
@@ -35,8 +35,10 @@ end
 #     cluster: "owens"
 cluster: "<%= cluster %>"
 
-title: "Jupyter Lab - CS 1090b - GPU"
+title: "Jupyter Lab - CS 1090b"
 description: |
+  This app is configured for GPU testing for CS 1090b, CS 2050, and BST 236.
+
   This app will launch a Jupyter Notebook server on one or more nodes. This
   configuration uses [Spack](https://spack.io/) to load a
   [Conda](https://anaconda.org/anaconda/conda) environment using

--- a/local/cs1090b.yml.erb
+++ b/local/cs1090b.yml.erb
@@ -1,0 +1,108 @@
+# Batch Connect app configuration file
+#
+# @note Used to define the submitted cluster, title, description, and
+#   hard-coded/user-defined attributes that make up this Batch Connect app.
+<%-
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name).flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+enabledGroups = [
+  # Cannot have other enabled groups if a course installation is in use
+  # This is because the course installation uses the course shared folder,
+  # which is not accessible to users outside of that course.
+  "137799",  # COMPSCI 1090A: Data Science 1: Introduction to Data Science
+  "135510"
+]
+
+def arrays_have_common_element(array1, array2)
+  # Use the `&` operator to get the intersection of the two arrays
+  # If the intersection is not empty, return true, otherwise false
+  !(array1 & array2).empty?
+end
+
+# Check if the groups that the user is in match any of the courses that should
+# have access to this app.
+
+if arrays_have_common_element(userGroups, enabledGroups)
+  cluster="*"
+else
+  cluster="disable_this_app"
+end
+-%>
+---
+
+# **MUST** set cluster id here that matches cluster configuration file located
+# under /etc/ood/config/clusters.d/*.yml
+# @example Use the Owens cluster at Ohio Supercomputer Center
+#     cluster: "owens"
+cluster: "<%= cluster %>"
+
+title: "Jupyter Lab - CS 1090b - GPU"
+description: |
+  This app will launch a Jupyter Notebook server on one or more nodes. This
+  configuration uses [Spack](https://spack.io/) to load a
+  [Conda](https://anaconda.org/anaconda/conda) environment using
+  [Miniconda](https://docs.anaconda.com/miniconda/) to load Jupyter Lab, and
+  was built for the course CS 1090a (and its cross-listed courses).<br/><br/>The
+  app launches outside of a container, so it has access to slurm commands, but
+  since the app is running as a slurm job, the `srun` command will use the
+  resources of the current job, rather than starting a new job. That is, unless
+  you first run an `salloc` command to allocate a new interactive session.
+
+# Do not cache the application form
+# The intent is to revert to the default Number of CPUs and Hours each time.
+cacheable: false
+
+# Define attribute values that aren't meant to be modified by the user within
+# the Dashboard form
+attributes:
+  course: "135510"
+  spack: "conda"
+  conda: "cs109b"
+  bc_queue: "gpu"
+  environment: "global"
+  #  widget: "radio_button"
+  #  value: "course"
+  #  help: |
+  #    Choose the environment used to launch Jupyter Lab. The "Course"
+  #    environment is managed by the teaching staff and has the latest
+  #    dependencies, while the "Global" environment is managed at the system
+  #    level and provides the initial set of dependencies.
+  #  options:
+  #    - ["Course (course managed)", "course"]
+  #    - ["Global (system managed)", "global"]
+
+  custom_num_cores:
+    widget: "number_field"
+    label: "Number of CPUs"
+    value: 1
+    min: 1
+    max: 4
+    step: 1
+
+  bc_num_hours:
+    value: 2
+    min: 1
+    max: 168  # 7 days max
+    step: 1
+
+  # Any extra command line arguments to feed to the `jupyter notebook ...`
+  # command that launches the Jupyter notebook within the batch job
+  extra_jupyter_args: ""
+
+# All of the attributes that make up the Dashboard form (in respective order),
+# and made available to the submit configuration file and the template ERB
+# files
+#
+# @note You typically do not need to modify this unless you want to add a new
+#   configurable value
+# @note If an attribute listed below is hard-coded above in the `attributes`
+#   option, then it will not appear in the form page that the user sees in the
+#   Dashboard
+form:
+  - course
+  - spack
+  - conda
+  - environment
+  - bc_queue
+  - extra_jupyter_args
+  - bc_num_hours
+  - custom_num_cores

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -24,3 +24,4 @@ script:
   native:
     - "--nodes=1"
     - "--cpus-per-task=<%= custom_num_cores.blank? ? 1 : custom_num_cores.to_i %>"
+    - "--gpus-per-node=<%= custom_num_gpus.blank? ? 0 : custom_num_gpus.to_i %>"

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -15,9 +15,14 @@ cd "${HOME}"
 # Select spack and conda environment based on form selection
 echo "Environment: <%= context.environment %>"
 if [[ "<%= context.environment %>" == "course" ]]; then
-    spack_root="/shared/courseSharedFolders/<%= context.course %>outer/<%= context.course %>/spack"
+    # spack_root="/shared/courseSharedFolders/<%= context.course %>outer/<%= context.course %>/spack"
+    spack_root="/shared/spack"
     spack_environment="<%= context.spack %>"
-    conda_environment="<%= context.conda %>"
+    # conda_environment="<%= context.conda %>"
+    conda_environment="/shared/courseSharedFolders/<%= context.course %>outer/<%= context.course %>/<%= context.conda %>"
+    # Check user access to conda environment
+    echo "Running ls on $conda_environment to check permissions"
+    ls $conda_environment
 else
     spack_root="/shared/spack"
     spack_environment="<%= context.spack %>"
@@ -46,9 +51,9 @@ echo "TIMING - Starting jupyter at: $(date -Iseconds)"
 
 # Activate conda environment
 echo "Loading conda environment: $conda_environment"
+set -x
 eval "$(command conda 'shell.bash' 'hook' 2> /dev/null)"
 conda activate $conda_environment
 
 # Launch the Jupyter Lab Server
-set -x
 jupyter lab --config="${CONFIG_FILE}" <%= context.extra_jupyter_args %>


### PR DESCRIPTION
# Overview

This PR sets up GPU environments for use in HUIT OOD. It includes two new course setups that use the GPU queue, CS 1090b and BST 236. Each of these includes a `form.yml.erb` style file in the `local` directory to control its behavior, and includes a `bc_queue` option to select the `gpu` partition in our setup.

# Changes

There are two new app configurations in the `local` directory that use the `gpu` queue, specified by the `bc_queue` option hard-coded to the form. Note that the `bc_queue` option must be set under the `attributes` and `form` yml keys in order for it to work when creating a new GPU app.

This PR also changes the way that the app setup handles course-controlled conda environments. Rather than relying on a downstream spack environment into which `miniconda3` must be installed, this setup uses the global spack environment for `conda` to create a conda environment in the course shared folder using the `--prefix` option when creating the conda environment. This cuts down on setup time for new environments using this app configuration. There is an accompanying PR in our scripts repository to make this setup easier: https://github.com/Harvard-ATG/atg-ood-scripts/pull/7

Another change in this PR is the addition of permissions to apps for admin users. This is done in the Ruby section of the `local/*.yml.erb` files created by the PR. It adds a check for if the user is included in an admin group, bypassing the check for course group membership if so and granting access to the app by setting the `cluster` to `*`. The fallback is the existing check for course group membership. Since this change also introduces the possibility that an admin user will not have access to a conda environment in a shared course folder that they do not have direct access to, it adds a folder permissions check in the form of trying to `ls` the folder containing the conda environment. If this fails, it will be visible in the `output.log` file that the user does not have permission to access the relevant environment, rather than a more ambiguous failure state.

# Notes

When installing Python packages that are intended to take advantage of the GPU, like `pytorch` and `tensorflow`, it's necessary to run their install process on a GPU-enabled node. So when setting up a conda environment for the GPU queue, run the conda install process on a GPU node, ideally using one of our install scripts via sbatch using `-p gpu`.

# References

- [`conda create` reference](https://docs.conda.io/projects/conda/en/latest/commands/create.html)
- [Manage conda environments](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html)