### PR TITLE
Add eps101 environment config

### DIFF
--- a/conda-environment/eps101/environment.yml
+++ b/conda-environment/eps101/environment.yml
@@ -1,0 +1,15 @@
+name: eps101
+
+channels:
+- conda-forge
+
+dependencies:
+- jupyterlab
+- numpy
+- pandas
+- matplotlib
+- scipy
+- requests
+- gsw
+- cartopy
+- netCDF4

--- a/local/eps101.yml.erb
+++ b/local/eps101.yml.erb
@@ -1,0 +1,83 @@
+# Batch Connect app configuration file
+#
+# @note Used to define the submitted cluster, title, description, and
+#   hard-coded/user-defined attributes that make up this Batch Connect app.
+<%-
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name).flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+enabledGroups = [
+  "135510", # HUIT Open OnDemand Testing
+  "141883"  # E-PSCI 101: Global Warming Science 101
+]
+
+def arrays_have_common_element(array1, array2)
+  # Use the `&` operator to get the intersection of the two arrays
+  # If the intersection is not empty, return true, otherwise false
+  !(array1 & array2).empty?
+end
+
+# Check if the groups that the user is in match any of the courses that should
+# have access to this app.
+
+if arrays_have_common_element(userGroups, enabledGroups)
+  cluster="*"
+else
+  cluster="disable_this_app"
+end
+-%>
+---
+
+# **MUST** set cluster id here that matches cluster configuration file located
+# under /etc/ood/config/clusters.d/*.yml
+# @example Use the Owens cluster at Ohio Supercomputer Center
+#     cluster: "owens"
+cluster: "<%= cluster %>"
+
+title: "Jupyter Lab - E-PSCI 101"
+description: |
+  This app will launch a Jupyter Notebook server on one or more nodes. This
+  configuration uses [Spack](https://spack.io/) to load a
+  [Conda](https://anaconda.org/anaconda/conda) environment using
+  [Miniconda](https://docs.anaconda.com/miniconda/) to load Jupyter Lab, and
+  was built for the course E-PSCI 101.<br/><br/>The app launches outside of a
+  container, so it has access to slurm commands, but since the app is running as
+  a slurm job, the `srun` command will use the resources of the current job,
+  rather than starting a new job. That is, unless you first run an `salloc`
+  command to allocate a new interactive session.
+
+# Define attribute values that aren't meant to be modified by the user within
+# the Dashboard form
+attributes:
+  course: "141883"
+  spack: "conda"
+  conda: "eps101"
+  environment: "global"
+
+  custom_num_cores:
+    widget: "number_field"
+    label: "Number of CPUs"
+    value: 1
+    min: 1
+    max: 4
+    step: 1
+
+  # Any extra command line arguments to feed to the `jupyter notebook ...`
+  # command that launches the Jupyter notebook within the batch job
+  extra_jupyter_args: ""
+
+# All of the attributes that make up the Dashboard form (in respective order),
+# and made available to the submit configuration file and the template ERB
+# files
+#
+# @note You typically do not need to modify this unless you want to add a new
+#   configurable value
+# @note If an attribute listed below is hard-coded above in the `attributes`
+#   option, then it will not appear in the form page that the user sees in the
+#   Dashboard
+form:
+  - course
+  - spack
+  - conda
+  - environment
+  - extra_jupyter_args
+  - bc_num_hours
+  - custom_num_cores


### PR DESCRIPTION
This PR adds a configuration for [E-PSCI 101: Global Warming Science 101](https://canvas.harvard.edu/courses/141883), which is a Spring 2025 course. The course requested several custom python libraries, so a conda environment has been setup along with a Sub-App.

Changes:
- Added `conda-environment/eps101/environment.yml`
- Configured sub-app in `local/eps101.yml.erb` enabled for the Spring course (canvas ID: 141883).

Notes:
- This does not create a separate spack environment for the course since there were no additional system dependencies needed.
- E-PSCI 101 is also offered as ESE 101.