### PR TITLE
Add BST 282 environment config

### DIFF
--- a/conda-environment/bst282/environment.yml
+++ b/conda-environment/bst282/environment.yml
@@ -17,3 +17,4 @@ dependencies:
 - bioconda::bwa
 - bioconda::minimap2
 - bioconda::sra-tools
+- bioconda::macs3

--- a/conda-environment/bst282/environment.yml
+++ b/conda-environment/bst282/environment.yml
@@ -1,0 +1,19 @@
+name: bst282
+
+channels:
+- conda-forge
+- bioconda
+
+dependencies:
+- jupyterlab
+- numpy
+- pandas
+- matplotlib
+- scipy
+- requests
+- pip
+- conda-forge::anndata
+- conda-forge::scanpy
+- bioconda::bwa
+- bioconda::minimap2
+- bioconda::sra-tools

--- a/local/bst282.yml.erb
+++ b/local/bst282.yml.erb
@@ -3,25 +3,37 @@
 # @note Used to define the submitted cluster, title, description, and
 #   hard-coded/user-defined attributes that make up this Batch Connect app.
 <%-
-userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name).flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
-enabledGroups = [
-  "135510", # HUIT Open OnDemand Testing
-  "150890"  # BST 282: Introduction to Computational Biology and Bioinformatics
-]
-
 def arrays_have_common_element(array1, array2)
   # Use the `&` operator to get the intersection of the two arrays
   # If the intersection is not empty, return true, otherwise false
   !(array1 & array2).empty?
 end
 
-# Check if the groups that the user is in match any of the courses that should
-# have access to this app.
-
-if arrays_have_common_element(userGroups, enabledGroups)
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name)
+# First check if the user is in an admin group
+adminGroups = [
+  "ondemand-admins-1025174" # HUIT OOD admin group, prod environment
+]
+if arrays_have_common_element(userGroups, adminGroups)
   cluster="*"
 else
-  cluster="disable_this_app"
+  # If the user is not in an admin group, check if they're in an authorized Canvas group
+  userCanvasGroups = userGroups.flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+  enabledGroups = [
+    # Cannot have other enabled groups if a course installation is in use
+    # This is because the course installation uses the course shared folder,
+    # which is not accessible to users outside of that course.
+    "150890"  # BST 282: Introduction to Computational Biology and Bioinformatics
+  ]
+
+  # Check if the groups that the user is in match any of the courses that should
+  # have access to this app.
+
+  if arrays_have_common_element(userGroups, enabledGroups)
+    cluster="*"
+  else
+    cluster="disable_this_app"
+  end
 end
 -%>
 ---

--- a/local/bst282.yml.erb
+++ b/local/bst282.yml.erb
@@ -1,0 +1,83 @@
+# Batch Connect app configuration file
+#
+# @note Used to define the submitted cluster, title, description, and
+#   hard-coded/user-defined attributes that make up this Batch Connect app.
+<%-
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name).flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+enabledGroups = [
+  "135510", # HUIT Open OnDemand Testing
+  "150890"  # BST 282: Introduction to Computational Biology and Bioinformatics
+]
+
+def arrays_have_common_element(array1, array2)
+  # Use the `&` operator to get the intersection of the two arrays
+  # If the intersection is not empty, return true, otherwise false
+  !(array1 & array2).empty?
+end
+
+# Check if the groups that the user is in match any of the courses that should
+# have access to this app.
+
+if arrays_have_common_element(userGroups, enabledGroups)
+  cluster="*"
+else
+  cluster="disable_this_app"
+end
+-%>
+---
+
+# **MUST** set cluster id here that matches cluster configuration file located
+# under /etc/ood/config/clusters.d/*.yml
+# @example Use the Owens cluster at Ohio Supercomputer Center
+#     cluster: "owens"
+cluster: "<%= cluster %>"
+
+title: "Jupyter Lab - BST 282"
+description: |
+  This app will launch a Jupyter Notebook server on one or more nodes. This
+  configuration uses [Spack](https://spack.io/) to load a
+  [Conda](https://anaconda.org/anaconda/conda) environment using
+  [Miniconda](https://docs.anaconda.com/miniconda/) to load Jupyter Lab, and
+  was built for the course BST 280.<br/><br/>The app launches outside of a
+  container, so it has access to slurm commands, but since the app is running as
+  a slurm job, the `srun` command will use the resources of the current job,
+  rather than starting a new job. That is, unless you first run an `salloc`
+  command to allocate a new interactive session.
+
+# Define attribute values that aren't meant to be modified by the user within
+# the Dashboard form
+attributes:
+  course: "150890"
+  spack: "bst282"
+  conda: "bst282"
+  environment: "global"
+
+  custom_num_cores:
+    widget: "number_field"
+    label: "Number of CPUs"
+    value: 1
+    min: 1
+    max: 4
+    step: 1
+
+  # Any extra command line arguments to feed to the `jupyter notebook ...`
+  # command that launches the Jupyter notebook within the batch job
+  extra_jupyter_args: ""
+
+# All of the attributes that make up the Dashboard form (in respective order),
+# and made available to the submit configuration file and the template ERB
+# files
+#
+# @note You typically do not need to modify this unless you want to add a new
+#   configurable value
+# @note If an attribute listed below is hard-coded above in the `attributes`
+#   option, then it will not appear in the form page that the user sees in the
+#   Dashboard
+form:
+  - course
+  - spack
+  - conda
+  - environment
+  - extra_jupyter_args
+  - bc_num_hours
+  - custom_num_cores

--- a/local/bst282.yml.erb
+++ b/local/bst282.yml.erb
@@ -38,7 +38,7 @@ description: |
   configuration uses [Spack](https://spack.io/) to load a
   [Conda](https://anaconda.org/anaconda/conda) environment using
   [Miniconda](https://docs.anaconda.com/miniconda/) to load Jupyter Lab, and
-  was built for the course BST 280.<br/><br/>The app launches outside of a
+  was built for the course BST 282.<br/><br/>The app launches outside of a
   container, so it has access to slurm commands, but since the app is running as
   a slurm job, the `srun` command will use the resources of the current job,
   rather than starting a new job. That is, unless you first run an `salloc`

--- a/local/bst282.yml.erb
+++ b/local/bst282.yml.erb
@@ -48,7 +48,7 @@ description: |
 # the Dashboard form
 attributes:
   course: "150890"
-  spack: "bst282"
+  spack: "conda"
   conda: "bst282"
   environment: "global"
 

--- a/spack-environment/bst282/spack.yml
+++ b/spack-environment/bst282/spack.yml
@@ -1,0 +1,19 @@
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+spack:
+  # add package specs to the `specs` list
+  specs:
+  - miniconda3
+#  - star
+#  - rsem
+#  - salmon
+#  - bowtie
+#  - hisat2
+#  - samtools
+#  - bedtools2
+#  - py-macs2
+  view: true
+  concretizer:
+    unify: true

--- a/spack-environment/bst282/spack.yml
+++ b/spack-environment/bst282/spack.yml
@@ -6,14 +6,13 @@ spack:
   # add package specs to the `specs` list
   specs:
   - miniconda3
-#  - star
-#  - rsem
-#  - salmon
-#  - bowtie
-#  - hisat2
-#  - samtools
-#  - bedtools2
-#  - py-macs2
+  - star
+  - rsem
+  - salmon
+  - bowtie
+  - hisat2
+  - samtools
+  - bedtools2
   view: true
   concretizer:
     unify: true


### PR DESCRIPTION
This PR adds a configuration for _BST 282: Introduction to Computational Biology and Bioinformatics_. Note that the course requested several additional C/C++ packages, so those have been added to the spack environment here. 

### Changes

- Added `conda-environment/bst282/environment.yml`.
- Added `spack-environment/bst282/spack.yml`.
- Added `local/bst282.yml.erb` sub-app for BST 282.

### Notes

#### Conda environment
Since a number of the requested packages come from https://bioconda.github.io/, but could also come from https://conda-forge.org/, the packages have been specified using the fully qualified form in a few cases so there is no ambiguity (i.e. `bioconda::minimap2` or `conda-forge::scanpy`). 

#### Spack environment

I manually updated the recipe for the `intel-tbb` package to resolve build errors that were coming up when installing the `salmon` package (`intel-tbb` is a dependency). The build errors were resolved with a new version of `intel-tbb`. The latest spack recipe contains the versions, but since we can't reliably update our local spack installation due to the breaking changes in v1.0.0, it's safer to make the changes manually. For reference, our spack installation in production is up-to-date as of Aug 2024 (commit `a60d108`).

File: `/shared/spack/var/spack/repos/builtin/packages/intel-tbb/package.py`

Changes:
```
git diff var/spack/repos/builtin/packages/intel-tbb/package.py
diff --git a/var/spack/repos/builtin/packages/intel-tbb/package.py b/var/spack/repos/builtin/packages/intel-tbb/package.py
index 7e1bff25ab..723f81c554 100644
--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -33,6 +33,8 @@ class IntelTbb(CMakePackage, MakefilePackage):
     license("Apache-2.0")

     version("master", branch="master")
+    version("2022.0.0", sha256="e8e89c9c345415b17b30a2db3095ba9d47647611662073f7fbf54ad48b7f3c2a") # added manually -abarrett 1/16/25
+    version("2021.13.0", sha256="3ad5dd08954b39d113dc5b3f8a8dc6dc1fd5250032b7c491eb07aed5c94133e1") # added manually -abarrett 1/16/25
```

See also: 
- [intel-tbb/package.py#L35-L36](https://github.com/spack/spack/blob/b78c5175823910bc1f57e59a07d0b8c636e3f02d/var/spack/repos/builtin/packages/intel-tbb/package.py#L35-L36)