### PR TITLE
Config changes for CS1090b

### DIFF
--- a/conda-environment/cs109a/environment.yml
+++ b/conda-environment/cs109a/environment.yml
@@ -1,27 +1,40 @@
-name: cs109a
+prefix: /shared/courseSharedFolders/142601outer/142601/cs109a
 
 channels:
 - conda-forge
 
 dependencies:
-# - asyncio # comes with python standard library
-- aiohttp
-- beautifulsoup4
-- jupyterlab
-- lxml
-- matplotlib
-- networkx
-- numpy
-- pandas
-- pillow
-- pip
-- python>=3.10
-- requests
-- scipy
-- scikit-learn
-- seaborn
-- selenium
-- statsmodels
-- pip:
-  - nbopen
-  - otter-grader
+  - aiohttp
+  - arviz
+  - beautifulsoup4
+  - imageio
+  - jupyterlab
+  - lxml
+  - matplotlib
+  - networkx
+  - nltk
+  - numpy
+  - pandas
+  - pillow
+  - pip
+  - pymc
+  - python>=3.10
+  - requests
+  - scipy
+  - scikit-image
+  - scikit-learn
+  - seaborn
+  - selenium
+  - statsmodels
+  - tensorflow==2.15.0
+  - tqdm
+  - pytorch==2.1.0
+  - pip:
+    - gap-stat
+    - nbopen
+    - opencv-python
+    - otter-grader
+    - tensorflow_addons==0.23.0
+    - tensorflow_datasets==4.9.4
+    - tensorflow_hub==0.16.0
+    - tf_keras_vis==0.8.6 # also adds keras

--- a/conda-environment/cs109b/environment.yml
+++ b/conda-environment/cs109b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
     - pymc==5.10.3
     - requests==2.31.0
     - scikit-learn==1.4.0
+    - scikit-image==0.24.0
     - scipy==1.12.0
     - seaborn==0.13.1
     - statsmodels==0.14.1
@@ -30,9 +31,10 @@ dependencies:
 
     - pip:
       - gap-stat==2.0.3
+      - opencv-python==4.11.0
       - nbopen==0.7
       - otter-grader==5.2.3
       - tensorflow_addons==0.23.0
       - tensorflow_datasets==4.9.4
       - tensorflow_hub==0.16.0
-      - tf_keras_vis==0.8.6
+      - tf_keras_vis==0.8.6 # also adds keras

--- a/local/cs1090a.yml.erb
+++ b/local/cs1090a.yml.erb
@@ -54,7 +54,7 @@ cacheable: false
 # Define attribute values that aren't meant to be modified by the user within
 # the Dashboard form
 attributes:
-  course: "137799"
+  course: "142601"
   spack: "cs109a"
   conda: "cs109a"
   environment:

--- a/local/cs1090a.yml.erb
+++ b/local/cs1090a.yml.erb
@@ -35,7 +35,7 @@ end
 #     cluster: "owens"
 cluster: "<%= cluster %>"
 
-title: "Jupyter Lab - CS 1090a"
+title: "Jupyter Lab - CS 1090a (CPU)"
 description: |
   This app will launch a Jupyter Notebook server on one or more nodes. This 
   configuration uses [Spack](https://spack.io/) to load a 


### PR DESCRIPTION
Enable the CS 1090a app for the spring course, point the form to the 109b folder for the conda environment.

This setup has been tested in the prod environment with a development app, and both the course and global apps were tested to confirm that they launch properly, and that they use the expected Python executable. The test for the executable was to run the following Python code in a notebook:

```python
import sys
sys.executable
```

This code indicated that the course environment correctly uses the conda environment in the course shared folder, and the global environment uses the conda environment in the conda spack environment.