### PR TITLE
Fix access check for BST 282

### DIFF
--- a/local/bst282.yml.erb
+++ b/local/bst282.yml.erb
@@ -29,7 +29,7 @@ else
   # Check if the groups that the user is in match any of the courses that should
   # have access to this app.
 
-  if arrays_have_common_element(userGroups, enabledGroups)
+  if arrays_have_common_element(userCanvasGroups, enabledGroups)
     cluster="*"
   else
     cluster="disable_this_app"


### PR DESCRIPTION
# Overview

This PR fixes the sub-app permission checking to ensure the users's canvas groups are checked to enable/disable the app.

# Changes

- Changed `userGroups` to  `userCanvasGroups` when checking against `enabledGroups`

