### PR TITLE
Enable course-managed conda environment for BST 282

### DIFF
--- a/local/bst282.yml.erb
+++ b/local/bst282.yml.erb
@@ -62,7 +62,17 @@ attributes:
   course: "150890"
   spack: "conda"
   conda: "bst282"
-  environment: "global"
+  environment:
+    widget: "radio_button"
+    value: "course"
+    help: |
+      Choose the environment used to launch Jupyter Lab. The "Course"
+      environment is managed by the teaching staff and has the latest
+      dependencies, while the "Global" environment is managed at the system
+      level and provides the initial set of dependencies.
+    options:
+      - ["Course (course managed)", "course"]
+      - ["Global (system managed)", "global"]
 
   custom_num_cores:
     widget: "number_field"


### PR DESCRIPTION
# Overview

This PR enables the course-managed conda environment for BST 282 so that course staff can manage the course packages, with a fallback to the globally managed conda environment.

# Changes

- Updated `local/bst282.yml.erb` so that the `environment` option allows users to switch between course/global environments.

# Notes

To setup the course shared environment, we are using the [--prefix](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#specifying-a-location-for-an-environment) option to relocate the conda environment to the course shared folder. The `template/script.sh.erb` in this repo is already configured to point to the conda environment.

When you run `conda env list`, it will show you where the global conda environments are stored. Since this is a known location, environments can be activated by name `conda activate bst282`. But when an environment is relocated to an arbitrary location, you must `conda activate /path/to/env` where the path is whatever you passed to `--prefix`. 

For BST 282, we have:

- **Global environment:** `/shared/spack/opt/spack/linux-amzn2-skylake_avx512/gcc-14.1.0/miniconda3-24.3.0-5gywilvzprk326axshjmzt3pscizgvxo/envs/bst282`
- **Course environment:** `/shared/courseSharedFolders/150890outer/150890/bst282` (i.e. the prefix)

Use the `courseConda.sh` utility script to do the actual course environment setup. This effectively does a `spack env activate` and `conda env create --prefix /path/to/env` along with the same conda environment YAML file that was used to setup the global environment.

Example:

```
sbatch -c 8 /shared/home/root/scripts/courseConda.sh bst282 /shared/home/root/environments/bst282/conda.yml /shared/courseSharedFolders/150890outer/150890/bst282
```

