### PR TITLE
Add Gened1188

### DIFF
--- a/conda-environment/gened1188/environment.yml
+++ b/conda-environment/gened1188/environment.yml
@@ -1,0 +1,15 @@
+name: gened1188
+
+channels:
+- conda-forge
+
+dependencies:
+- jupyterlab
+- matplotlib
+- numpy
+- pip
+- python>=3.11
+- scipy
+- scikit-learn
+- pytorch-cpu
+

--- a/local/gened1188.yml.erb
+++ b/local/gened1188.yml.erb
@@ -1,0 +1,94 @@
+# Batch Connect app configuration file
+#
+# @note Used to define the submitted cluster, title, description, and
+#   hard-coded/user-defined attributes that make up this Batch Connect app.
+<%-
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name).flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+enabledGroups = [
+  "135510", # HUIT Open OnDemand Testing
+  "144313"  # GENED 1188: Rise of the Machines? Understanding and Using Generative AI
+  
+]
+
+def arrays_have_common_element(array1, array2)
+  # Use the `&` operator to get the intersection of the two arrays
+  # If the intersection is not empty, return true, otherwise false
+  !(array1 & array2).empty?
+end
+
+# Check if the groups that the user is in match any of the courses that should 
+# have access to this app.
+
+if arrays_have_common_element(userGroups, enabledGroups)
+  cluster="*"
+else
+  cluster="disable_this_app"
+end
+-%>
+---
+
+# **MUST** set cluster id here that matches cluster configuration file located
+# under /etc/ood/config/clusters.d/*.yml
+# @example Use the Owens cluster at Ohio Supercomputer Center
+#     cluster: "owens"
+cluster: "<%= cluster %>"
+
+title: "Jupyter Lab - GENED 1188"
+description: |
+  This app will launch a Jupyter Notebook server on one or more nodes. This 
+  configuration uses [Spack](https://spack.io/) to load a 
+  [Conda](https://anaconda.org/anaconda/conda) environment using 
+  [Miniconda](https://docs.anaconda.com/miniconda/) to load Jupyter Lab, and 
+  was built for the course GOV 99R.<br/><br/>The app launches outside of a
+  container, so it has access to slurm commands, but since the app is running as
+  a slurm job, the `srun` command will use the resources of the current job,
+  rather than starting a new job. That is, unless you first run an `salloc`
+  command to allocate a new interactive session.
+
+# Define attribute values that aren't meant to be modified by the user within
+# the Dashboard form
+attributes:
+  course: "144313"
+  spack: "gened1188"
+  conda: "gened1188"
+  environment:
+    widget: "radio_button"
+    value: "course"
+    help: |
+      Choose the environment used to launch Jupyter Lab. The "Course" 
+      environment is managed by the teaching staff and has the latest 
+      dependencies, while the "Global" environment is managed at the system 
+      level and provides the initial set of dependencies.
+    options:
+      - ["Course (course managed)", "course"]
+      - ["Global (system managed)", "global"]
+
+  custom_num_cores:
+    widget: "number_field"
+    label: "Number of CPUs"
+    value: 1
+    min: 1
+    max: 4
+    step: 1
+
+  # Any extra command line arguments to feed to the `jupyter notebook ...`
+  # command that launches the Jupyter notebook within the batch job
+  extra_jupyter_args: ""
+
+# All of the attributes that make up the Dashboard form (in respective order),
+# and made available to the submit configuration file and the template ERB
+# files
+#
+# @note You typically do not need to modify this unless you want to add a new
+#   configurable value
+# @note If an attribute listed below is hard-coded above in the `attributes`
+#   option, then it will not appear in the form page that the user sees in the
+#   Dashboard
+form:
+  - course
+  - spack
+  - conda
+  - environment
+  - extra_jupyter_args
+  - bc_num_hours
+  - custom_num_cores

--- a/local/gened1188.yml.erb
+++ b/local/gened1188.yml.erb
@@ -39,7 +39,7 @@ description: |
   configuration uses [Spack](https://spack.io/) to load a 
   [Conda](https://anaconda.org/anaconda/conda) environment using 
   [Miniconda](https://docs.anaconda.com/miniconda/) to load Jupyter Lab, and 
-  was built for the course GOV 99R.<br/><br/>The app launches outside of a
+  was built for the course GENED 1188.<br/><br/>The app launches outside of a
   container, so it has access to slurm commands, but since the app is running as
   a slurm job, the `srun` command will use the resources of the current job,
   rather than starting a new job. That is, unless you first run an `salloc`

--- a/local/gened1188.yml.erb
+++ b/local/gened1188.yml.erb
@@ -3,26 +3,38 @@
 # @note Used to define the submitted cluster, title, description, and
 #   hard-coded/user-defined attributes that make up this Batch Connect app.
 <%-
-userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name).flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
-enabledGroups = [
-  "135510", # HUIT Open OnDemand Testing
-  "144313"  # GENED 1188: Rise of the Machines? Understanding and Using Generative AI
-  
-]
-
 def arrays_have_common_element(array1, array2)
   # Use the `&` operator to get the intersection of the two arrays
   # If the intersection is not empty, return true, otherwise false
   !(array1 & array2).empty?
 end
 
-# Check if the groups that the user is in match any of the courses that should 
-# have access to this app.
-
-if arrays_have_common_element(userGroups, enabledGroups)
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name)
+# First check if the user is in an admin group
+adminGroups = [
+  "ondemand-admins-1025174" # HUIT OOD admin group, prod environment
+]
+if arrays_have_common_element(userGroups, adminGroups)
   cluster="*"
 else
-  cluster="disable_this_app"
+  # If the user is not in an admin group, check if they're in an authorized Canvas group
+  userCanvasGroups = userGroups.flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+  enabledGroups = [
+    # Cannot have other enabled groups if a course installation is in use
+    # This is because the course installation uses the course shared folder,
+    # which is not accessible to users outside of that course.
+    "144313"  # GENED 1188: Rise of the Machines? Understanding and Using Generative AI
+
+  ]
+
+  # Check if the groups that the user is in match any of the courses that should
+  # have access to this app.
+
+  if arrays_have_common_element(userCanvasGroups, enabledGroups)
+    cluster="*"
+  else
+    cluster="disable_this_app"
+  end
 end
 -%>
 ---

--- a/spack-environment/gened1188/spack.yml
+++ b/spack-environment/gened1188/spack.yml
@@ -10,4 +10,4 @@ spack:
   - lazygit
   view: true
   concretizer:
-    unify: true
+    unify: when_possible

--- a/spack-environment/gened1188/spack.yml
+++ b/spack-environment/gened1188/spack.yml
@@ -1,0 +1,13 @@
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+spack:
+  # add package specs to the `specs` list
+  specs:
+  - miniconda3
+  - git
+  - lazygit
+  view: true
+  concretizer:
+    unify: true

--- a/spack-environment/gened1188/spack.yml
+++ b/spack-environment/gened1188/spack.yml
@@ -10,4 +10,4 @@ spack:
   - lazygit
   view: true
   concretizer:
-    unify: when_possible
+    unify: true


### PR DESCRIPTION
# Overview
This PR adds `gened1188` course to OOD sub-apps.
# Changes
- Added `environment.yml` to `conda-environments`
- Added `spack.yml` to `spack-conda`
- Added `yml.erb` configuration to use `Course` and `Global` conda environment
# Notes
- If you are working with course specific conda, make sure you have permissions in the course otherwise you run into permissions error when the instance tries to access the course specific conda environment
- Use this script [courseConda.sh](https://github.com/Harvard-ATG/atg-ood-scripts/blob/main/courseConda.sh) when adding course specific conda environments
