### PR TITLE
Fix issues with exporting to PDF

### DIFF
--- a/conda-environment/apmth91r/environment.yml
+++ b/conda-environment/apmth91r/environment.yml
@@ -7,6 +7,7 @@ dependencies:
 # - asyncio # comes with python standard library
 - aiohttp
 - jupyterlab
+- pandoc
 - matplotlib
 - numpy
 - pandas

--- a/conda-environment/bst236/environment.yml
+++ b/conda-environment/bst236/environment.yml
@@ -5,6 +5,7 @@ channels:
 
 dependencies:
 - jupyterlab
+- pandoc
 - numpy
 - pandas
 - matplotlib

--- a/conda-environment/bst280/environment.yml
+++ b/conda-environment/bst280/environment.yml
@@ -5,6 +5,7 @@ channels:
 
 dependencies:
 - jupyterlab
+- pandoc
 - numpy
 - pandas
 - matplotlib

--- a/conda-environment/bst282/environment.yml
+++ b/conda-environment/bst282/environment.yml
@@ -6,6 +6,7 @@ channels:
 
 dependencies:
 - jupyterlab
+- pandoc
 - numpy
 - pandas
 - matplotlib

--- a/conda-environment/cs109a/environment.yml
+++ b/conda-environment/cs109a/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - beautifulsoup4
   - imageio
   - jupyterlab
+  - pandoc
   - lxml
   - matplotlib
   - networkx

--- a/conda-environment/cs109b/environment.yml
+++ b/conda-environment/cs109b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
     - imageio==2.33.1
     - ipython==8.20.0
     - jupyterlab==4.0.11
+    - pandoc
     - matplotlib==3.8.2
     - nltk==3.8.1
     - numpy==1.26.3

--- a/conda-environment/eps101/environment.yml
+++ b/conda-environment/eps101/environment.yml
@@ -5,6 +5,7 @@ channels:
 
 dependencies:
 - jupyterlab
+- pandoc
 - numpy
 - pandas
 - matplotlib

--- a/conda-environment/gened1188/environment.yml
+++ b/conda-environment/gened1188/environment.yml
@@ -5,6 +5,7 @@ channels:
 
 dependencies:
 - jupyterlab
+- pandoc
 - matplotlib
 - numpy
 - pip

--- a/conda-environment/gov99r/environment.yml
+++ b/conda-environment/gov99r/environment.yml
@@ -8,6 +8,7 @@ dependencies:
 - aiohttp
 - beautifulsoup4
 - jupyterlab
+- pandoc
 - lxml
 - matplotlib
 - networkx

--- a/conda-environment/jupyter/environment.yml
+++ b/conda-environment/jupyter/environment.yml
@@ -5,6 +5,7 @@ channels:
 
 dependencies:
 - jupyterlab
+- pandoc
 - numpy
 - pandas
 - matplotlib

--- a/conda-environment/oeb252/environment.yml
+++ b/conda-environment/oeb252/environment.yml
@@ -8,6 +8,7 @@ dependencies:
 - python>=3.10
 - pip:
   - jupyterlab
+  - pandoc
   - numpy
   - pandas
   - matplotlib

--- a/spack-environment/bst280/spack.yml
+++ b/spack-environment/bst280/spack.yml
@@ -6,6 +6,7 @@ spack:
   # add package specs to the `specs` list
   specs:
   - miniconda3
+  - texlive
   - hdf5
   - openmpi@4.1.1
   view: true

--- a/spack-environment/bst282/spack.yml
+++ b/spack-environment/bst282/spack.yml
@@ -6,6 +6,7 @@ spack:
   # add package specs to the `specs` list
   specs:
   - miniconda3
+  - texlive
   - star
   - rsem
   - salmon

--- a/spack-environment/conda/spack.yml
+++ b/spack-environment/conda/spack.yml
@@ -6,6 +6,7 @@ spack:
   # add package specs to the `specs` list
   specs:
   - miniconda3
+  - texlive
   view: true
   concretizer:
     unify: true

--- a/spack-environment/cs109a/spack.yml
+++ b/spack-environment/cs109a/spack.yml
@@ -6,6 +6,7 @@ spack:
   # add package specs to the `specs` list
   specs:
   - miniconda3
+  - texlive
   - git
   - lazygit
   # - zsh

--- a/spack-environment/gened1188/spack.yml
+++ b/spack-environment/gened1188/spack.yml
@@ -6,6 +6,7 @@ spack:
   # add package specs to the `specs` list
   specs:
   - miniconda3
+  - texlive
   - git
   - lazygit
   view: true

--- a/spack-environment/oeb252/spack.yml
+++ b/spack-environment/oeb252/spack.yml
@@ -6,6 +6,7 @@ spack:
   # add package specs to the `specs` list
   specs:
   - miniconda3
+  - texlive
   - admixtools
   - bcftools
   - plink


### PR DESCRIPTION
# Overview

This PR is in response to one part of the issues reported in [INC05762454](https://harvard.service-now.com/nav_to.do?uri=incident.do?sys_id=77028913935352d04cf93f9a7bba10eb) in our ticketing system, where students reported an error when trying to export a Jupyter Notebook to PDF. The error indicated that `pandoc`, a Python package, could not be found.

This PR will be marked ready for review when I've tested the EPS 101 environment and found that I am able to export a notebook to PDF. 

# Changes

This PR adds that dependency to the conda environments for all of the setups in this repository. It also adds the `texlive` package to the Spack environment definitions, as a new error about that dependency not being found was the next error to come up after `pandoc` was installed.

# Notes

# References
