### PR TITLE
Feature/cs1060

### DIFF
--- a/conda-environment/cs1060/environment.yml
+++ b/conda-environment/cs1060/environment.yml
@@ -1,0 +1,17 @@
+name: jupyter
+
+channels:
+- conda-forge
+
+dependencies:
+- jupyterlab
+- numpy
+- pandas
+- matplotlib
+- scipy
+- pip
+- python>=3.10
+- requests
+- pytorch>=1.8
+- pip:
+  - ultralytics

--- a/conda-environment/cs1060/environment.yml
+++ b/conda-environment/cs1060/environment.yml
@@ -14,4 +14,9 @@ dependencies:
 - requests
 - pytorch>=1.8
 - pip:
+  - torch --index-url https://download.pytorch.org/whl/cu124
+  - torchvision --index-url https://download.pytorch.org/whl/cu124
+  - torchaudio --index-url https://download.pytorch.org/whl/cu124
+  - onnx>=1.12.0
+  - onnxslim
   - ultralytics

--- a/conda-environment/cs1060/environment.yml
+++ b/conda-environment/cs1060/environment.yml
@@ -1,4 +1,4 @@
-name: jupyter
+name: cs1060
 
 channels:
 - conda-forge

--- a/local/cs1060.yml.erb
+++ b/local/cs1060.yml.erb
@@ -42,15 +42,15 @@ end
 # under /etc/ood/config/clusters.d/*.yml
 cluster: "<%= cluster %>"
 
-title: "Jupyter Lab - COMPSCI 1060 (GPU)"
+title: "Jupyter Lab - CS 1060 (GPU)"
 description: |
-  This app is configured for GPU access for COMPSCI 1060.
+  This app is configured for GPU access for CS 1060.
 
   This app will launch a Jupyter Notebook server on one or more nodes. This
   configuration uses [Spack](https://spack.io/) to load a
   [Conda](https://anaconda.org/anaconda/conda) environment using
   [Miniconda](https://docs.anaconda.com/miniconda/) to load Jupyter Lab, and
-  was built for the course COMPSCI 1060.<br/><br/>The
+  was built for the course CS 1060.<br/><br/>The
   app launches outside of a container, so it has access to slurm commands, but
   since the app is running as a slurm job, the `srun` command will use the
   resources of the current job, rather than starting a new job. That is, unless

--- a/local/cs1060.yml.erb
+++ b/local/cs1060.yml.erb
@@ -50,7 +50,7 @@ description: |
   configuration uses [Spack](https://spack.io/) to load a
   [Conda](https://anaconda.org/anaconda/conda) environment using
   [Miniconda](https://docs.anaconda.com/miniconda/) to load Jupyter Lab, and
-  was built for the course Neuro 140 (and its cross-listed courses).<br/><br/>The
+  was built for the course COMPSCI 1060.<br/><br/>The
   app launches outside of a container, so it has access to slurm commands, but
   since the app is running as a slurm job, the `srun` command will use the
   resources of the current job, rather than starting a new job. That is, unless

--- a/local/cs1060.yml.erb
+++ b/local/cs1060.yml.erb
@@ -1,0 +1,109 @@
+# Batch Connect app configuration file
+#
+# @note Used to define the submitted cluster, title, description, and
+#   hard-coded/user-defined attributes that make up this Batch Connect app.
+<%-
+def arrays_have_common_element(array1, array2)
+  # Use the `&` operator to get the intersection of the two arrays
+  # If the intersection is not empty, return true, otherwise false
+  !(array1 & array2).empty?
+end
+
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name)
+# First check if the user is in an admin group
+adminGroups = [
+  "ondemand-admins-1025174" # HUIT OOD admin group, prod environment
+]
+if arrays_have_common_element(userGroups, adminGroups)
+  cluster="*"
+else
+  # If the user is not in an admin group, check if they're in an authorized Canvas group
+  userCanvasGroups = userGroups.flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+  enabledGroups = [
+    # Cannot have other enabled groups if a course installation is in use
+    # This is because the course installation uses the course shared folder,
+    # which is not accessible to users outside of that course.
+    "151688" # COMPSCI 1060: Software Engineering with Generative AI
+  ]
+
+  # Check if the groups that the user is in match any of the courses that should
+  # have access to this app.
+
+  if arrays_have_common_element(userCanvasGroups, enabledGroups)
+    cluster="*"
+  else
+    cluster="disable_this_app"
+  end
+end
+-%>
+---
+
+# **MUST** set cluster id here that matches cluster configuration file located
+# under /etc/ood/config/clusters.d/*.yml
+cluster: "<%= cluster %>"
+
+title: "Jupyter Lab - COMPSCI 1060 (GPU)"
+description: |
+  This app is configured for GPU access for COMPSCI 1060.
+
+  This app will launch a Jupyter Notebook server on one or more nodes. This
+  configuration uses [Spack](https://spack.io/) to load a
+  [Conda](https://anaconda.org/anaconda/conda) environment using
+  [Miniconda](https://docs.anaconda.com/miniconda/) to load Jupyter Lab, and
+  was built for the course Neuro 140 (and its cross-listed courses).<br/><br/>The
+  app launches outside of a container, so it has access to slurm commands, but
+  since the app is running as a slurm job, the `srun` command will use the
+  resources of the current job, rather than starting a new job. That is, unless
+  you first run an `salloc` command to allocate a new interactive session.
+
+# Do not cache the application form
+# The intent is to revert to the default Number of CPUs and Hours each time.
+cacheable: false
+
+# Define attribute values that aren't meant to be modified by the user within
+# the Dashboard form
+attributes:
+  course: "151688"
+  spack: "conda"
+  conda: "cs1060"
+  bc_queue: "gpu"
+  environment: "global"
+
+  custom_num_cores: 8
+  custom_num_gpus: 1
+  # custom_num_cores:
+  #   widget: "number_field"
+  #   label: "Number of CPUs"
+  #   value: 1
+  #   min: 1
+  #   max: 4
+  #   step: 1
+
+  bc_num_hours:
+    value: 2
+    min: 1
+    max: 6  # 6 hours max
+    step: 1
+
+  # Any extra command line arguments to feed to the `jupyter notebook ...`
+  # command that launches the Jupyter notebook within the batch job
+  extra_jupyter_args: ""
+
+# All of the attributes that make up the Dashboard form (in respective order),
+# and made available to the submit configuration file and the template ERB
+# files
+#
+# @note You typically do not need to modify this unless you want to add a new
+#   configurable value
+# @note If an attribute listed below is hard-coded above in the `attributes`
+#   option, then it will not appear in the form page that the user sees in the
+#   Dashboard
+form:
+  - course
+  - spack
+  - conda
+  - environment
+  - bc_queue
+  - extra_jupyter_args
+  - bc_num_hours
+  - custom_num_cores


### PR DESCRIPTION
# Overview

Add support for CS 1060 requested Python packages, namely [`ultralytics`](https://github.com/ultralytics/ultralytics), which requires `torch`.

# Changes

Add a conda environment for CS 1060, and an OOD sub-app to use that environment. The sub-app is not configured for a course-controlled conda environment.

# Notes

The `ultralytics` package is non-trivial to use. I tested it with code from the [Ultralytics quickstart](https://docs.ultralytics.com/quickstart/):

```python
from ultralytics import YOLO

# Create a new YOLO model from scratch
model = YOLO("yolo11n.yaml")

# Load a pretrained YOLO model (recommended for training)
model = YOLO("yolo11n.pt")

# Train the model using the 'coco8.yaml' dataset for 3 epochs
results = model.train(data="coco8.yaml", epochs=3)

# Evaluate the model's performance on the validation set
results = model.val()

# Perform object detection on an image using the model
results = model("https://ultralytics.com/images/bus.jpg")

# Export the model to ONNX format
success = model.export(format="onnx")
```

In testing this, I encountered an issue where training the model created problems where the package attempted to save its files under `/shared/spack` for reasons that are unclear to me. I was able to change this save directory by updating the settings for `ultralytics` like so:

```python
import os
from ultralytics import settings

settings.update({
    'runs_dir': os.path.expanduser('~/ultralytics/runs'),
    'datasets_dir': os.path.expanduser('~/ultralytics/datasets'),
    'weights_dir': os.path.expanduser('~/ultralytics/weights')
})
```

After updating the settings, the Python kernel needs to be reloaded. The settings changes appear to persist across sessions, stored in `~/.config/Ultralytics/settings.json`

When exporting the model to the ONNX format, `ultralytics` attempts to download several Python packages to handle this export. Since users don't have access to the system `conda` environment, this fails. I added two of these packages, `onnx` and `onnxslim` to the `conda` environment definition. A third, `onnxruntime-gpu` could not be installed. This library only provides pre-built wheels, not a source distribution, and none of the wheels are compatible with the operating system we're running. See the [`onnxruntime-gpu` downloads page](https://pypi.org/project/onnxruntime-gpu/#files) for the available wheels.

I was able to find out why the wheels wouldn't work by running `python -m pip debug --verbose`, as proposed in a [StackOverflow post about a similar issue](https://stackoverflow.com/a/63117182/2344915). Our system is compatible with `cp312-cp312-manylinux_2_26_x86_64`, but the wheels require `manylinux_2_27` or `manylinux_2_28`. Because of this, I wasn't able to install the package, but the export appears to succeed nonetheless. It still tries to install the library, but proceeds with the export anyway when it fails to install `onnxruntime-gpu`, at least when the other `onnx` libraries are available.

<details>
  <summary>pip debug output</summary>

```
WARNING: This command is only meant for debugging. Do not use this with automation for parsing and getting these details, since the output and options of this command may change without notice.
pip version: pip 25.0.1 from /shared/spack/opt/spack/linux-amzn2-skylake_avx512/gcc-14.1.0/miniconda3-24.3.0-zxx5jostrj4myhf7bi3oap3ylkmegd3a/envs/cs1060/lib/python3.12/site-packages/pip (python 3.12)
sys.version: 3.12.9 | packaged by conda-forge | (main, Feb 14 2025, 08:00:06) [GCC 13.3.0]
sys.executable: /shared/spack/opt/spack/linux-amzn2-skylake_avx512/gcc-14.1.0/miniconda3-24.3.0-zxx5jostrj4myhf7bi3oap3ylkmegd3a/envs/cs1060/bin/python
sys.getdefaultencoding: utf-8
sys.getfilesystemencoding: utf-8
locale.getpreferredencoding: UTF-8
sys.platform: linux
sys.implementation:
  name: cpython
'cert' config value: Not specified
REQUESTS_CA_BUNDLE: None
CURL_CA_BUNDLE: None
pip._vendor.certifi.where(): /shared/spack/opt/spack/linux-amzn2-skylake_avx512/gcc-14.1.0/miniconda3-24.3.0-zxx5jostrj4myhf7bi3oap3ylkmegd3a/envs/cs1060/lib/python3.12/site-packages/pip/_vendor/certifi/cacert.pem
pip._vendor.DEBUNDLED: False
vendored library versions:
  CacheControl==0.14.1
  distlib==0.3.9
  distro==1.9.0
  msgpack==1.1.0
  packaging==24.2
  platformdirs==4.3.6
  pyproject-hooks==1.2.0
  requests==2.32.3
  certifi==2024.08.30
  idna==3.10
  urllib3==1.26.20
  rich==13.9.4 (Unable to locate actual module version, using vendor.txt specified version)
  pygments==2.18.0
  typing_extensions==4.12.2 (Unable to locate actual module version, using vendor.txt specified version)
  resolvelib==1.0.1
  setuptools==70.3.0 (Unable to locate actual module version, using vendor.txt specified version)
  tomli==2.2.1
  truststore==0.10.0
Compatible tags: 717
  cp312-cp312-manylinux_2_26_x86_64
  cp312-cp312-manylinux_2_25_x86_64
  cp312-cp312-manylinux_2_24_x86_64
  cp312-cp312-manylinux_2_23_x86_64
  cp312-cp312-manylinux_2_22_x86_64
  cp312-cp312-manylinux_2_21_x86_64
  cp312-cp312-manylinux_2_20_x86_64
  cp312-cp312-manylinux_2_19_x86_64
  cp312-cp312-manylinux_2_18_x86_64
  cp312-cp312-manylinux_2_17_x86_64
  cp312-cp312-manylinux2014_x86_64
  cp312-cp312-manylinux_2_16_x86_64
  cp312-cp312-manylinux_2_15_x86_64
  cp312-cp312-manylinux_2_14_x86_64
  cp312-cp312-manylinux_2_13_x86_64
  cp312-cp312-manylinux_2_12_x86_64
  cp312-cp312-manylinux2010_x86_64
  cp312-cp312-manylinux_2_11_x86_64
  cp312-cp312-manylinux_2_10_x86_64
  cp312-cp312-manylinux_2_9_x86_64
  cp312-cp312-manylinux_2_8_x86_64
  cp312-cp312-manylinux_2_7_x86_64
  cp312-cp312-manylinux_2_6_x86_64
  cp312-cp312-manylinux_2_5_x86_64
  cp312-cp312-manylinux1_x86_64
  cp312-cp312-linux_x86_64
  cp312-abi3-manylinux_2_26_x86_64
  cp312-abi3-manylinux_2_25_x86_64
  cp312-abi3-manylinux_2_24_x86_64
  cp312-abi3-manylinux_2_23_x86_64
  cp312-abi3-manylinux_2_22_x86_64
  cp312-abi3-manylinux_2_21_x86_64
  cp312-abi3-manylinux_2_20_x86_64
  cp312-abi3-manylinux_2_19_x86_64
  cp312-abi3-manylinux_2_18_x86_64
  cp312-abi3-manylinux_2_17_x86_64
  cp312-abi3-manylinux2014_x86_64
  cp312-abi3-manylinux_2_16_x86_64
  cp312-abi3-manylinux_2_15_x86_64
  cp312-abi3-manylinux_2_14_x86_64
  cp312-abi3-manylinux_2_13_x86_64
  cp312-abi3-manylinux_2_12_x86_64
  cp312-abi3-manylinux2010_x86_64
  cp312-abi3-manylinux_2_11_x86_64
  cp312-abi3-manylinux_2_10_x86_64
  cp312-abi3-manylinux_2_9_x86_64
  cp312-abi3-manylinux_2_8_x86_64
  cp312-abi3-manylinux_2_7_x86_64
  cp312-abi3-manylinux_2_6_x86_64
  cp312-abi3-manylinux_2_5_x86_64
  cp312-abi3-manylinux1_x86_64
  cp312-abi3-linux_x86_64
  cp312-none-manylinux_2_26_x86_64
  cp312-none-manylinux_2_25_x86_64
  cp312-none-manylinux_2_24_x86_64
  cp312-none-manylinux_2_23_x86_64
  cp312-none-manylinux_2_22_x86_64
  cp312-none-manylinux_2_21_x86_64
  cp312-none-manylinux_2_20_x86_64
  cp312-none-manylinux_2_19_x86_64
  cp312-none-manylinux_2_18_x86_64
  cp312-none-manylinux_2_17_x86_64
  cp312-none-manylinux2014_x86_64
  cp312-none-manylinux_2_16_x86_64
  cp312-none-manylinux_2_15_x86_64
  cp312-none-manylinux_2_14_x86_64
  cp312-none-manylinux_2_13_x86_64
  cp312-none-manylinux_2_12_x86_64
  cp312-none-manylinux2010_x86_64
  cp312-none-manylinux_2_11_x86_64
  cp312-none-manylinux_2_10_x86_64
  cp312-none-manylinux_2_9_x86_64
  cp312-none-manylinux_2_8_x86_64
  cp312-none-manylinux_2_7_x86_64
  cp312-none-manylinux_2_6_x86_64
  cp312-none-manylinux_2_5_x86_64
  cp312-none-manylinux1_x86_64
  cp312-none-linux_x86_64
  cp311-abi3-manylinux_2_26_x86_64
  cp311-abi3-manylinux_2_25_x86_64
  cp311-abi3-manylinux_2_24_x86_64
  cp311-abi3-manylinux_2_23_x86_64
  cp311-abi3-manylinux_2_22_x86_64
  cp311-abi3-manylinux_2_21_x86_64
  cp311-abi3-manylinux_2_20_x86_64
  cp311-abi3-manylinux_2_19_x86_64
  cp311-abi3-manylinux_2_18_x86_64
  cp311-abi3-manylinux_2_17_x86_64
  cp311-abi3-manylinux2014_x86_64
  cp311-abi3-manylinux_2_16_x86_64
  cp311-abi3-manylinux_2_15_x86_64
  cp311-abi3-manylinux_2_14_x86_64
  cp311-abi3-manylinux_2_13_x86_64
  cp311-abi3-manylinux_2_12_x86_64
  cp311-abi3-manylinux2010_x86_64
  cp311-abi3-manylinux_2_11_x86_64
  cp311-abi3-manylinux_2_10_x86_64
  cp311-abi3-manylinux_2_9_x86_64
  cp311-abi3-manylinux_2_8_x86_64
  cp311-abi3-manylinux_2_7_x86_64
  cp311-abi3-manylinux_2_6_x86_64
  cp311-abi3-manylinux_2_5_x86_64
  cp311-abi3-manylinux1_x86_64
  cp311-abi3-linux_x86_64
  cp310-abi3-manylinux_2_26_x86_64
  cp310-abi3-manylinux_2_25_x86_64
  cp310-abi3-manylinux_2_24_x86_64
  cp310-abi3-manylinux_2_23_x86_64
  cp310-abi3-manylinux_2_22_x86_64
  cp310-abi3-manylinux_2_21_x86_64
  cp310-abi3-manylinux_2_20_x86_64
  cp310-abi3-manylinux_2_19_x86_64
  cp310-abi3-manylinux_2_18_x86_64
  cp310-abi3-manylinux_2_17_x86_64
  cp310-abi3-manylinux2014_x86_64
  cp310-abi3-manylinux_2_16_x86_64
  cp310-abi3-manylinux_2_15_x86_64
  cp310-abi3-manylinux_2_14_x86_64
  cp310-abi3-manylinux_2_13_x86_64
  cp310-abi3-manylinux_2_12_x86_64
  cp310-abi3-manylinux2010_x86_64
  cp310-abi3-manylinux_2_11_x86_64
  cp310-abi3-manylinux_2_10_x86_64
  cp310-abi3-manylinux_2_9_x86_64
  cp310-abi3-manylinux_2_8_x86_64
  cp310-abi3-manylinux_2_7_x86_64
  cp310-abi3-manylinux_2_6_x86_64
  cp310-abi3-manylinux_2_5_x86_64
  cp310-abi3-manylinux1_x86_64
  cp310-abi3-linux_x86_64
  cp39-abi3-manylinux_2_26_x86_64
  cp39-abi3-manylinux_2_25_x86_64
  cp39-abi3-manylinux_2_24_x86_64
  cp39-abi3-manylinux_2_23_x86_64
  cp39-abi3-manylinux_2_22_x86_64
  cp39-abi3-manylinux_2_21_x86_64
  cp39-abi3-manylinux_2_20_x86_64
  cp39-abi3-manylinux_2_19_x86_64
  cp39-abi3-manylinux_2_18_x86_64
  cp39-abi3-manylinux_2_17_x86_64
  cp39-abi3-manylinux2014_x86_64
  cp39-abi3-manylinux_2_16_x86_64
  cp39-abi3-manylinux_2_15_x86_64
  cp39-abi3-manylinux_2_14_x86_64
  cp39-abi3-manylinux_2_13_x86_64
  cp39-abi3-manylinux_2_12_x86_64
  cp39-abi3-manylinux2010_x86_64
  cp39-abi3-manylinux_2_11_x86_64
  cp39-abi3-manylinux_2_10_x86_64
  cp39-abi3-manylinux_2_9_x86_64
  cp39-abi3-manylinux_2_8_x86_64
  cp39-abi3-manylinux_2_7_x86_64
  cp39-abi3-manylinux_2_6_x86_64
  cp39-abi3-manylinux_2_5_x86_64
  cp39-abi3-manylinux1_x86_64
  cp39-abi3-linux_x86_64
  cp38-abi3-manylinux_2_26_x86_64
  cp38-abi3-manylinux_2_25_x86_64
  cp38-abi3-manylinux_2_24_x86_64
  cp38-abi3-manylinux_2_23_x86_64
  cp38-abi3-manylinux_2_22_x86_64
  cp38-abi3-manylinux_2_21_x86_64
  cp38-abi3-manylinux_2_20_x86_64
  cp38-abi3-manylinux_2_19_x86_64
  cp38-abi3-manylinux_2_18_x86_64
  cp38-abi3-manylinux_2_17_x86_64
  cp38-abi3-manylinux2014_x86_64
  cp38-abi3-manylinux_2_16_x86_64
  cp38-abi3-manylinux_2_15_x86_64
  cp38-abi3-manylinux_2_14_x86_64
  cp38-abi3-manylinux_2_13_x86_64
  cp38-abi3-manylinux_2_12_x86_64
  cp38-abi3-manylinux2010_x86_64
  cp38-abi3-manylinux_2_11_x86_64
  cp38-abi3-manylinux_2_10_x86_64
  cp38-abi3-manylinux_2_9_x86_64
  cp38-abi3-manylinux_2_8_x86_64
  cp38-abi3-manylinux_2_7_x86_64
  cp38-abi3-manylinux_2_6_x86_64
  cp38-abi3-manylinux_2_5_x86_64
  cp38-abi3-manylinux1_x86_64
  cp38-abi3-linux_x86_64
  cp37-abi3-manylinux_2_26_x86_64
  cp37-abi3-manylinux_2_25_x86_64
  cp37-abi3-manylinux_2_24_x86_64
  cp37-abi3-manylinux_2_23_x86_64
  cp37-abi3-manylinux_2_22_x86_64
  cp37-abi3-manylinux_2_21_x86_64
  cp37-abi3-manylinux_2_20_x86_64
  cp37-abi3-manylinux_2_19_x86_64
  cp37-abi3-manylinux_2_18_x86_64
  cp37-abi3-manylinux_2_17_x86_64
  cp37-abi3-manylinux2014_x86_64
  cp37-abi3-manylinux_2_16_x86_64
  cp37-abi3-manylinux_2_15_x86_64
  cp37-abi3-manylinux_2_14_x86_64
  cp37-abi3-manylinux_2_13_x86_64
  cp37-abi3-manylinux_2_12_x86_64
  cp37-abi3-manylinux2010_x86_64
  cp37-abi3-manylinux_2_11_x86_64
  cp37-abi3-manylinux_2_10_x86_64
  cp37-abi3-manylinux_2_9_x86_64
  cp37-abi3-manylinux_2_8_x86_64
  cp37-abi3-manylinux_2_7_x86_64
  cp37-abi3-manylinux_2_6_x86_64
  cp37-abi3-manylinux_2_5_x86_64
  cp37-abi3-manylinux1_x86_64
  cp37-abi3-linux_x86_64
  cp36-abi3-manylinux_2_26_x86_64
  cp36-abi3-manylinux_2_25_x86_64
  cp36-abi3-manylinux_2_24_x86_64
  cp36-abi3-manylinux_2_23_x86_64
  cp36-abi3-manylinux_2_22_x86_64
  cp36-abi3-manylinux_2_21_x86_64
  cp36-abi3-manylinux_2_20_x86_64
  cp36-abi3-manylinux_2_19_x86_64
  cp36-abi3-manylinux_2_18_x86_64
  cp36-abi3-manylinux_2_17_x86_64
  cp36-abi3-manylinux2014_x86_64
  cp36-abi3-manylinux_2_16_x86_64
  cp36-abi3-manylinux_2_15_x86_64
  cp36-abi3-manylinux_2_14_x86_64
  cp36-abi3-manylinux_2_13_x86_64
  cp36-abi3-manylinux_2_12_x86_64
  cp36-abi3-manylinux2010_x86_64
  cp36-abi3-manylinux_2_11_x86_64
  cp36-abi3-manylinux_2_10_x86_64
  cp36-abi3-manylinux_2_9_x86_64
  cp36-abi3-manylinux_2_8_x86_64
  cp36-abi3-manylinux_2_7_x86_64
  cp36-abi3-manylinux_2_6_x86_64
  cp36-abi3-manylinux_2_5_x86_64
  cp36-abi3-manylinux1_x86_64
  cp36-abi3-linux_x86_64
  cp35-abi3-manylinux_2_26_x86_64
  cp35-abi3-manylinux_2_25_x86_64
  cp35-abi3-manylinux_2_24_x86_64
  cp35-abi3-manylinux_2_23_x86_64
  cp35-abi3-manylinux_2_22_x86_64
  cp35-abi3-manylinux_2_21_x86_64
  cp35-abi3-manylinux_2_20_x86_64
  cp35-abi3-manylinux_2_19_x86_64
  cp35-abi3-manylinux_2_18_x86_64
  cp35-abi3-manylinux_2_17_x86_64
  cp35-abi3-manylinux2014_x86_64
  cp35-abi3-manylinux_2_16_x86_64
  cp35-abi3-manylinux_2_15_x86_64
  cp35-abi3-manylinux_2_14_x86_64
  cp35-abi3-manylinux_2_13_x86_64
  cp35-abi3-manylinux_2_12_x86_64
  cp35-abi3-manylinux2010_x86_64
  cp35-abi3-manylinux_2_11_x86_64
  cp35-abi3-manylinux_2_10_x86_64
  cp35-abi3-manylinux_2_9_x86_64
  cp35-abi3-manylinux_2_8_x86_64
  cp35-abi3-manylinux_2_7_x86_64
  cp35-abi3-manylinux_2_6_x86_64
  cp35-abi3-manylinux_2_5_x86_64
  cp35-abi3-manylinux1_x86_64
  cp35-abi3-linux_x86_64
  cp34-abi3-manylinux_2_26_x86_64
  cp34-abi3-manylinux_2_25_x86_64
  cp34-abi3-manylinux_2_24_x86_64
  cp34-abi3-manylinux_2_23_x86_64
  cp34-abi3-manylinux_2_22_x86_64
  cp34-abi3-manylinux_2_21_x86_64
  cp34-abi3-manylinux_2_20_x86_64
  cp34-abi3-manylinux_2_19_x86_64
  cp34-abi3-manylinux_2_18_x86_64
  cp34-abi3-manylinux_2_17_x86_64
  cp34-abi3-manylinux2014_x86_64
  cp34-abi3-manylinux_2_16_x86_64
  cp34-abi3-manylinux_2_15_x86_64
  cp34-abi3-manylinux_2_14_x86_64
  cp34-abi3-manylinux_2_13_x86_64
  cp34-abi3-manylinux_2_12_x86_64
  cp34-abi3-manylinux2010_x86_64
  cp34-abi3-manylinux_2_11_x86_64
  cp34-abi3-manylinux_2_10_x86_64
  cp34-abi3-manylinux_2_9_x86_64
  cp34-abi3-manylinux_2_8_x86_64
  cp34-abi3-manylinux_2_7_x86_64
  cp34-abi3-manylinux_2_6_x86_64
  cp34-abi3-manylinux_2_5_x86_64
  cp34-abi3-manylinux1_x86_64
  cp34-abi3-linux_x86_64
  cp33-abi3-manylinux_2_26_x86_64
  cp33-abi3-manylinux_2_25_x86_64
  cp33-abi3-manylinux_2_24_x86_64
  cp33-abi3-manylinux_2_23_x86_64
  cp33-abi3-manylinux_2_22_x86_64
  cp33-abi3-manylinux_2_21_x86_64
  cp33-abi3-manylinux_2_20_x86_64
  cp33-abi3-manylinux_2_19_x86_64
  cp33-abi3-manylinux_2_18_x86_64
  cp33-abi3-manylinux_2_17_x86_64
  cp33-abi3-manylinux2014_x86_64
  cp33-abi3-manylinux_2_16_x86_64
  cp33-abi3-manylinux_2_15_x86_64
  cp33-abi3-manylinux_2_14_x86_64
  cp33-abi3-manylinux_2_13_x86_64
  cp33-abi3-manylinux_2_12_x86_64
  cp33-abi3-manylinux2010_x86_64
  cp33-abi3-manylinux_2_11_x86_64
  cp33-abi3-manylinux_2_10_x86_64
  cp33-abi3-manylinux_2_9_x86_64
  cp33-abi3-manylinux_2_8_x86_64
  cp33-abi3-manylinux_2_7_x86_64
  cp33-abi3-manylinux_2_6_x86_64
  cp33-abi3-manylinux_2_5_x86_64
  cp33-abi3-manylinux1_x86_64
  cp33-abi3-linux_x86_64
  cp32-abi3-manylinux_2_26_x86_64
  cp32-abi3-manylinux_2_25_x86_64
  cp32-abi3-manylinux_2_24_x86_64
  cp32-abi3-manylinux_2_23_x86_64
  cp32-abi3-manylinux_2_22_x86_64
  cp32-abi3-manylinux_2_21_x86_64
  cp32-abi3-manylinux_2_20_x86_64
  cp32-abi3-manylinux_2_19_x86_64
  cp32-abi3-manylinux_2_18_x86_64
  cp32-abi3-manylinux_2_17_x86_64
  cp32-abi3-manylinux2014_x86_64
  cp32-abi3-manylinux_2_16_x86_64
  cp32-abi3-manylinux_2_15_x86_64
  cp32-abi3-manylinux_2_14_x86_64
  cp32-abi3-manylinux_2_13_x86_64
  cp32-abi3-manylinux_2_12_x86_64
  cp32-abi3-manylinux2010_x86_64
  cp32-abi3-manylinux_2_11_x86_64
  cp32-abi3-manylinux_2_10_x86_64
  cp32-abi3-manylinux_2_9_x86_64
  cp32-abi3-manylinux_2_8_x86_64
  cp32-abi3-manylinux_2_7_x86_64
  cp32-abi3-manylinux_2_6_x86_64
  cp32-abi3-manylinux_2_5_x86_64
  cp32-abi3-manylinux1_x86_64
  cp32-abi3-linux_x86_64
  py312-none-manylinux_2_26_x86_64
  py312-none-manylinux_2_25_x86_64
  py312-none-manylinux_2_24_x86_64
  py312-none-manylinux_2_23_x86_64
  py312-none-manylinux_2_22_x86_64
  py312-none-manylinux_2_21_x86_64
  py312-none-manylinux_2_20_x86_64
  py312-none-manylinux_2_19_x86_64
  py312-none-manylinux_2_18_x86_64
  py312-none-manylinux_2_17_x86_64
  py312-none-manylinux2014_x86_64
  py312-none-manylinux_2_16_x86_64
  py312-none-manylinux_2_15_x86_64
  py312-none-manylinux_2_14_x86_64
  py312-none-manylinux_2_13_x86_64
  py312-none-manylinux_2_12_x86_64
  py312-none-manylinux2010_x86_64
  py312-none-manylinux_2_11_x86_64
  py312-none-manylinux_2_10_x86_64
  py312-none-manylinux_2_9_x86_64
  py312-none-manylinux_2_8_x86_64
  py312-none-manylinux_2_7_x86_64
  py312-none-manylinux_2_6_x86_64
  py312-none-manylinux_2_5_x86_64
  py312-none-manylinux1_x86_64
  py312-none-linux_x86_64
  py3-none-manylinux_2_26_x86_64
  py3-none-manylinux_2_25_x86_64
  py3-none-manylinux_2_24_x86_64
  py3-none-manylinux_2_23_x86_64
  py3-none-manylinux_2_22_x86_64
  py3-none-manylinux_2_21_x86_64
  py3-none-manylinux_2_20_x86_64
  py3-none-manylinux_2_19_x86_64
  py3-none-manylinux_2_18_x86_64
  py3-none-manylinux_2_17_x86_64
  py3-none-manylinux2014_x86_64
  py3-none-manylinux_2_16_x86_64
  py3-none-manylinux_2_15_x86_64
  py3-none-manylinux_2_14_x86_64
  py3-none-manylinux_2_13_x86_64
  py3-none-manylinux_2_12_x86_64
  py3-none-manylinux2010_x86_64
  py3-none-manylinux_2_11_x86_64
  py3-none-manylinux_2_10_x86_64
  py3-none-manylinux_2_9_x86_64
  py3-none-manylinux_2_8_x86_64
  py3-none-manylinux_2_7_x86_64
  py3-none-manylinux_2_6_x86_64
  py3-none-manylinux_2_5_x86_64
  py3-none-manylinux1_x86_64
  py3-none-linux_x86_64
  py311-none-manylinux_2_26_x86_64
  py311-none-manylinux_2_25_x86_64
  py311-none-manylinux_2_24_x86_64
  py311-none-manylinux_2_23_x86_64
  py311-none-manylinux_2_22_x86_64
  py311-none-manylinux_2_21_x86_64
  py311-none-manylinux_2_20_x86_64
  py311-none-manylinux_2_19_x86_64
  py311-none-manylinux_2_18_x86_64
  py311-none-manylinux_2_17_x86_64
  py311-none-manylinux2014_x86_64
  py311-none-manylinux_2_16_x86_64
  py311-none-manylinux_2_15_x86_64
  py311-none-manylinux_2_14_x86_64
  py311-none-manylinux_2_13_x86_64
  py311-none-manylinux_2_12_x86_64
  py311-none-manylinux2010_x86_64
  py311-none-manylinux_2_11_x86_64
  py311-none-manylinux_2_10_x86_64
  py311-none-manylinux_2_9_x86_64
  py311-none-manylinux_2_8_x86_64
  py311-none-manylinux_2_7_x86_64
  py311-none-manylinux_2_6_x86_64
  py311-none-manylinux_2_5_x86_64
  py311-none-manylinux1_x86_64
  py311-none-linux_x86_64
  py310-none-manylinux_2_26_x86_64
  py310-none-manylinux_2_25_x86_64
  py310-none-manylinux_2_24_x86_64
  py310-none-manylinux_2_23_x86_64
  py310-none-manylinux_2_22_x86_64
  py310-none-manylinux_2_21_x86_64
  py310-none-manylinux_2_20_x86_64
  py310-none-manylinux_2_19_x86_64
  py310-none-manylinux_2_18_x86_64
  py310-none-manylinux_2_17_x86_64
  py310-none-manylinux2014_x86_64
  py310-none-manylinux_2_16_x86_64
  py310-none-manylinux_2_15_x86_64
  py310-none-manylinux_2_14_x86_64
  py310-none-manylinux_2_13_x86_64
  py310-none-manylinux_2_12_x86_64
  py310-none-manylinux2010_x86_64
  py310-none-manylinux_2_11_x86_64
  py310-none-manylinux_2_10_x86_64
  py310-none-manylinux_2_9_x86_64
  py310-none-manylinux_2_8_x86_64
  py310-none-manylinux_2_7_x86_64
  py310-none-manylinux_2_6_x86_64
  py310-none-manylinux_2_5_x86_64
  py310-none-manylinux1_x86_64
  py310-none-linux_x86_64
  py39-none-manylinux_2_26_x86_64
  py39-none-manylinux_2_25_x86_64
  py39-none-manylinux_2_24_x86_64
  py39-none-manylinux_2_23_x86_64
  py39-none-manylinux_2_22_x86_64
  py39-none-manylinux_2_21_x86_64
  py39-none-manylinux_2_20_x86_64
  py39-none-manylinux_2_19_x86_64
  py39-none-manylinux_2_18_x86_64
  py39-none-manylinux_2_17_x86_64
  py39-none-manylinux2014_x86_64
  py39-none-manylinux_2_16_x86_64
  py39-none-manylinux_2_15_x86_64
  py39-none-manylinux_2_14_x86_64
  py39-none-manylinux_2_13_x86_64
  py39-none-manylinux_2_12_x86_64
  py39-none-manylinux2010_x86_64
  py39-none-manylinux_2_11_x86_64
  py39-none-manylinux_2_10_x86_64
  py39-none-manylinux_2_9_x86_64
  py39-none-manylinux_2_8_x86_64
  py39-none-manylinux_2_7_x86_64
  py39-none-manylinux_2_6_x86_64
  py39-none-manylinux_2_5_x86_64
  py39-none-manylinux1_x86_64
  py39-none-linux_x86_64
  py38-none-manylinux_2_26_x86_64
  py38-none-manylinux_2_25_x86_64
  py38-none-manylinux_2_24_x86_64
  py38-none-manylinux_2_23_x86_64
  py38-none-manylinux_2_22_x86_64
  py38-none-manylinux_2_21_x86_64
  py38-none-manylinux_2_20_x86_64
  py38-none-manylinux_2_19_x86_64
  py38-none-manylinux_2_18_x86_64
  py38-none-manylinux_2_17_x86_64
  py38-none-manylinux2014_x86_64
  py38-none-manylinux_2_16_x86_64
  py38-none-manylinux_2_15_x86_64
  py38-none-manylinux_2_14_x86_64
  py38-none-manylinux_2_13_x86_64
  py38-none-manylinux_2_12_x86_64
  py38-none-manylinux2010_x86_64
  py38-none-manylinux_2_11_x86_64
  py38-none-manylinux_2_10_x86_64
  py38-none-manylinux_2_9_x86_64
  py38-none-manylinux_2_8_x86_64
  py38-none-manylinux_2_7_x86_64
  py38-none-manylinux_2_6_x86_64
  py38-none-manylinux_2_5_x86_64
  py38-none-manylinux1_x86_64
  py38-none-linux_x86_64
  py37-none-manylinux_2_26_x86_64
  py37-none-manylinux_2_25_x86_64
  py37-none-manylinux_2_24_x86_64
  py37-none-manylinux_2_23_x86_64
  py37-none-manylinux_2_22_x86_64
  py37-none-manylinux_2_21_x86_64
  py37-none-manylinux_2_20_x86_64
  py37-none-manylinux_2_19_x86_64
  py37-none-manylinux_2_18_x86_64
  py37-none-manylinux_2_17_x86_64
  py37-none-manylinux2014_x86_64
  py37-none-manylinux_2_16_x86_64
  py37-none-manylinux_2_15_x86_64
  py37-none-manylinux_2_14_x86_64
  py37-none-manylinux_2_13_x86_64
  py37-none-manylinux_2_12_x86_64
  py37-none-manylinux2010_x86_64
  py37-none-manylinux_2_11_x86_64
  py37-none-manylinux_2_10_x86_64
  py37-none-manylinux_2_9_x86_64
  py37-none-manylinux_2_8_x86_64
  py37-none-manylinux_2_7_x86_64
  py37-none-manylinux_2_6_x86_64
  py37-none-manylinux_2_5_x86_64
  py37-none-manylinux1_x86_64
  py37-none-linux_x86_64
  py36-none-manylinux_2_26_x86_64
  py36-none-manylinux_2_25_x86_64
  py36-none-manylinux_2_24_x86_64
  py36-none-manylinux_2_23_x86_64
  py36-none-manylinux_2_22_x86_64
  py36-none-manylinux_2_21_x86_64
  py36-none-manylinux_2_20_x86_64
  py36-none-manylinux_2_19_x86_64
  py36-none-manylinux_2_18_x86_64
  py36-none-manylinux_2_17_x86_64
  py36-none-manylinux2014_x86_64
  py36-none-manylinux_2_16_x86_64
  py36-none-manylinux_2_15_x86_64
  py36-none-manylinux_2_14_x86_64
  py36-none-manylinux_2_13_x86_64
  py36-none-manylinux_2_12_x86_64
  py36-none-manylinux2010_x86_64
  py36-none-manylinux_2_11_x86_64
  py36-none-manylinux_2_10_x86_64
  py36-none-manylinux_2_9_x86_64
  py36-none-manylinux_2_8_x86_64
  py36-none-manylinux_2_7_x86_64
  py36-none-manylinux_2_6_x86_64
  py36-none-manylinux_2_5_x86_64
  py36-none-manylinux1_x86_64
  py36-none-linux_x86_64
  py35-none-manylinux_2_26_x86_64
  py35-none-manylinux_2_25_x86_64
  py35-none-manylinux_2_24_x86_64
  py35-none-manylinux_2_23_x86_64
  py35-none-manylinux_2_22_x86_64
  py35-none-manylinux_2_21_x86_64
  py35-none-manylinux_2_20_x86_64
  py35-none-manylinux_2_19_x86_64
  py35-none-manylinux_2_18_x86_64
  py35-none-manylinux_2_17_x86_64
  py35-none-manylinux2014_x86_64
  py35-none-manylinux_2_16_x86_64
  py35-none-manylinux_2_15_x86_64
  py35-none-manylinux_2_14_x86_64
  py35-none-manylinux_2_13_x86_64
  py35-none-manylinux_2_12_x86_64
  py35-none-manylinux2010_x86_64
  py35-none-manylinux_2_11_x86_64
  py35-none-manylinux_2_10_x86_64
  py35-none-manylinux_2_9_x86_64
  py35-none-manylinux_2_8_x86_64
  py35-none-manylinux_2_7_x86_64
  py35-none-manylinux_2_6_x86_64
  py35-none-manylinux_2_5_x86_64
  py35-none-manylinux1_x86_64
  py35-none-linux_x86_64
  py34-none-manylinux_2_26_x86_64
  py34-none-manylinux_2_25_x86_64
  py34-none-manylinux_2_24_x86_64
  py34-none-manylinux_2_23_x86_64
  py34-none-manylinux_2_22_x86_64
  py34-none-manylinux_2_21_x86_64
  py34-none-manylinux_2_20_x86_64
  py34-none-manylinux_2_19_x86_64
  py34-none-manylinux_2_18_x86_64
  py34-none-manylinux_2_17_x86_64
  py34-none-manylinux2014_x86_64
  py34-none-manylinux_2_16_x86_64
  py34-none-manylinux_2_15_x86_64
  py34-none-manylinux_2_14_x86_64
  py34-none-manylinux_2_13_x86_64
  py34-none-manylinux_2_12_x86_64
  py34-none-manylinux2010_x86_64
  py34-none-manylinux_2_11_x86_64
  py34-none-manylinux_2_10_x86_64
  py34-none-manylinux_2_9_x86_64
  py34-none-manylinux_2_8_x86_64
  py34-none-manylinux_2_7_x86_64
  py34-none-manylinux_2_6_x86_64
  py34-none-manylinux_2_5_x86_64
  py34-none-manylinux1_x86_64
  py34-none-linux_x86_64
  py33-none-manylinux_2_26_x86_64
  py33-none-manylinux_2_25_x86_64
  py33-none-manylinux_2_24_x86_64
  py33-none-manylinux_2_23_x86_64
  py33-none-manylinux_2_22_x86_64
  py33-none-manylinux_2_21_x86_64
  py33-none-manylinux_2_20_x86_64
  py33-none-manylinux_2_19_x86_64
  py33-none-manylinux_2_18_x86_64
  py33-none-manylinux_2_17_x86_64
  py33-none-manylinux2014_x86_64
  py33-none-manylinux_2_16_x86_64
  py33-none-manylinux_2_15_x86_64
  py33-none-manylinux_2_14_x86_64
  py33-none-manylinux_2_13_x86_64
  py33-none-manylinux_2_12_x86_64
  py33-none-manylinux2010_x86_64
  py33-none-manylinux_2_11_x86_64
  py33-none-manylinux_2_10_x86_64
  py33-none-manylinux_2_9_x86_64
  py33-none-manylinux_2_8_x86_64
  py33-none-manylinux_2_7_x86_64
  py33-none-manylinux_2_6_x86_64
  py33-none-manylinux_2_5_x86_64
  py33-none-manylinux1_x86_64
  py33-none-linux_x86_64
  py32-none-manylinux_2_26_x86_64
  py32-none-manylinux_2_25_x86_64
  py32-none-manylinux_2_24_x86_64
  py32-none-manylinux_2_23_x86_64
  py32-none-manylinux_2_22_x86_64
  py32-none-manylinux_2_21_x86_64
  py32-none-manylinux_2_20_x86_64
  py32-none-manylinux_2_19_x86_64
  py32-none-manylinux_2_18_x86_64
  py32-none-manylinux_2_17_x86_64
  py32-none-manylinux2014_x86_64
  py32-none-manylinux_2_16_x86_64
  py32-none-manylinux_2_15_x86_64
  py32-none-manylinux_2_14_x86_64
  py32-none-manylinux_2_13_x86_64
  py32-none-manylinux_2_12_x86_64
  py32-none-manylinux2010_x86_64
  py32-none-manylinux_2_11_x86_64
  py32-none-manylinux_2_10_x86_64
  py32-none-manylinux_2_9_x86_64
  py32-none-manylinux_2_8_x86_64
  py32-none-manylinux_2_7_x86_64
  py32-none-manylinux_2_6_x86_64
  py32-none-manylinux_2_5_x86_64
  py32-none-manylinux1_x86_64
  py32-none-linux_x86_64
  py31-none-manylinux_2_26_x86_64
  py31-none-manylinux_2_25_x86_64
  py31-none-manylinux_2_24_x86_64
  py31-none-manylinux_2_23_x86_64
  py31-none-manylinux_2_22_x86_64
  py31-none-manylinux_2_21_x86_64
  py31-none-manylinux_2_20_x86_64
  py31-none-manylinux_2_19_x86_64
  py31-none-manylinux_2_18_x86_64
  py31-none-manylinux_2_17_x86_64
  py31-none-manylinux2014_x86_64
  py31-none-manylinux_2_16_x86_64
  py31-none-manylinux_2_15_x86_64
  py31-none-manylinux_2_14_x86_64
  py31-none-manylinux_2_13_x86_64
  py31-none-manylinux_2_12_x86_64
  py31-none-manylinux2010_x86_64
  py31-none-manylinux_2_11_x86_64
  py31-none-manylinux_2_10_x86_64
  py31-none-manylinux_2_9_x86_64
  py31-none-manylinux_2_8_x86_64
  py31-none-manylinux_2_7_x86_64
  py31-none-manylinux_2_6_x86_64
  py31-none-manylinux_2_5_x86_64
  py31-none-manylinux1_x86_64
  py31-none-linux_x86_64
  py30-none-manylinux_2_26_x86_64
  py30-none-manylinux_2_25_x86_64
  py30-none-manylinux_2_24_x86_64
  py30-none-manylinux_2_23_x86_64
  py30-none-manylinux_2_22_x86_64
  py30-none-manylinux_2_21_x86_64
  py30-none-manylinux_2_20_x86_64
  py30-none-manylinux_2_19_x86_64
  py30-none-manylinux_2_18_x86_64
  py30-none-manylinux_2_17_x86_64
  py30-none-manylinux2014_x86_64
  py30-none-manylinux_2_16_x86_64
  py30-none-manylinux_2_15_x86_64
  py30-none-manylinux_2_14_x86_64
  py30-none-manylinux_2_13_x86_64
  py30-none-manylinux_2_12_x86_64
  py30-none-manylinux2010_x86_64
  py30-none-manylinux_2_11_x86_64
  py30-none-manylinux_2_10_x86_64
  py30-none-manylinux_2_9_x86_64
  py30-none-manylinux_2_8_x86_64
  py30-none-manylinux_2_7_x86_64
  py30-none-manylinux_2_6_x86_64
  py30-none-manylinux_2_5_x86_64
  py30-none-manylinux1_x86_64
  py30-none-linux_x86_64
  cp312-none-any
  py312-none-any
  py3-none-any
  py311-none-any
  py310-none-any
  py39-none-any
  py38-none-any
  py37-none-any
  py36-none-any
  py35-none-any
  py34-none-any
  py33-none-any
  py32-none-any
  py31-none-any
  py30-none-any
```
</details>

The `manylinux` compatibility uses the system's `glibc` version as a guide for compatibility, and running `ldd --version` as suggested in a [StackOverflow post](https://stackoverflow.com/questions/9705660/check-glibc-version-for-a-particular-gcc-compiler) does indeed show that our OS uses version 2.26. I tried adding `gcc@14.1.0` to the environment, but this didn't have any impact on the output of `ldd --version` or the pip debug output. If there is a way to change the environment to make it compatible with the pre-built wheels for `onnxruntime-gpu`, that path would require additional testing and research, and I'm not certain that it would meet with success.

# References

- [StackOverflow on pip debug output](https://stackoverflow.com/a/63117182/2344915)
- [`onnxruntime-gpu` download files](https://pypi.org/project/onnxruntime-gpu/#files)
- [Ultralytics quickstart](https://docs.ultralytics.com/quickstart/#use-ultralytics-with-cli)
- [Manylinux docs in GitHub](https://github.com/pypa/manylinux)
- [Check glibc version](https://stackoverflow.com/questions/9705660/check-glibc-version-for-a-particular-gcc-compiler)