### PR TITLE
Feature/gpu multitenant

### DIFF
--- a/local/astron205.yml.erb
+++ b/local/astron205.yml.erb
@@ -66,7 +66,7 @@ attributes:
   course: "144258"
   spack: "conda"
   conda: "astron205"
-  bc_queue: "gpu"
+  bc_queue: "gpu-parallel"
   environment: "global"
 
   custom_num_cores: 8
@@ -107,3 +107,4 @@ form:
   - extra_jupyter_args
   - bc_num_hours
   - custom_num_cores
+  - custom_num_gpus

--- a/local/bst236.yml.erb
+++ b/local/bst236.yml.erb
@@ -66,7 +66,7 @@ attributes:
   course: "150579"
   spack: "conda"
   conda: "bst236"
-  bc_queue: "gpu"
+  bc_queue: "gpu-parallel"
   environment:
     widget: "radio_button"
     value: "course"
@@ -117,3 +117,4 @@ form:
   - extra_jupyter_args
   - bc_num_hours
   - custom_num_cores
+  - custom_num_gpus

--- a/local/cs1060.yml.erb
+++ b/local/cs1060.yml.erb
@@ -66,7 +66,7 @@ attributes:
   course: "151688"
   spack: "conda"
   conda: "cs1060"
-  bc_queue: "gpu"
+  bc_queue: "gpu-parallel"
   environment: "global"
 
   custom_num_cores: 8
@@ -107,3 +107,4 @@ form:
   - extra_jupyter_args
   - bc_num_hours
   - custom_num_cores
+  - custom_num_gpus

--- a/local/cs1090b.yml.erb
+++ b/local/cs1090b.yml.erb
@@ -66,7 +66,7 @@ attributes:
   course: "142601"
   spack: "conda"
   conda: "cs109b"
-  bc_queue: "gpu"
+  bc_queue: "gpu-parallel"
   environment:
     widget: "radio_button"
     value: "course"

--- a/local/cs1090b.yml.erb
+++ b/local/cs1090b.yml.erb
@@ -117,3 +117,4 @@ form:
   - extra_jupyter_args
   - bc_num_hours
   - custom_num_cores
+  - custom_num_gpus

--- a/local/neuro140.yml.erb
+++ b/local/neuro140.yml.erb
@@ -66,7 +66,7 @@ attributes:
   course: "143051"
   spack: "conda"
   conda: "neuro140"
-  bc_queue: "gpu"
+  bc_queue: "gpu-parallel"
   environment: "global"
 
   custom_num_cores: 8
@@ -107,3 +107,4 @@ form:
   - extra_jupyter_args
   - bc_num_hours
   - custom_num_cores
+  - custom_num_gpus

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -24,4 +24,4 @@ script:
   native:
     - "--nodes=1"
     - "--cpus-per-task=<%= custom_num_cores.blank? ? 1 : custom_num_cores.to_i %>"
-    - "--gpus-per-node=<%= custom_num_gpus.blank? ? 0 : custom_num_gpus.to_i %>"
+    - "--gres=gpu:<%= custom_num_gpus.blank? ? 0 : custom_num_gpus.to_i %>"


### PR DESCRIPTION
# Overview

See [Using multi-GPU instances for Jupyter Lab](https://docs.google.com/document/d/1hW65s7T-jybsbsquDaV5j2pyFW3jFfbAmX7WsDbTQD8/edit) doc for details on the broader slurm changes, as well as app changes.

## Configuring the Jupyter App to use a single GPU

The arguments included in the Slurm command to start the Jupyter App job control the resources allocated to that job, including GPU resources. Like with CPU resources, these are configured with a "native" option in the submit.yml.erb file in the app. In this case, the file has been modified to include a line for --gres=gpu:<%= custom_num_gpus.blank? ? 0 : custom_num_gpus.to_i %>, pulling a custom variable from the form.yml config to determine the number of GPUs to provide.

This custom variable is set in the form.yml, or in the file within local that defines a sub-app in OOD. This allows some apps to be configured with GPU resources, and some without. For the GPU apps, this can be hard-coded as a form attribute, like custom_num_gpus: 1. Just don't forget to also add custom_num_gpus under the form section as well, otherwise the setting won't take effect.

For apps that don't require GPUs, the custom_num_gpus setting can be left blank. It will be defaulted to 0, which places no restrictions or requirements on GPU resources. That means that as long as the app is configured to use a non-GPU partition, it won't be looking for any GPU resources. However, it's worth noting that if the app does get configured for use in a GPU partition, the app won't have a limit on its access to GPU resources on the node. I don't know of any case where we'd ever want a job to run on a GPU node, but not use the GPU, since GPU nodes are so expensive to run. The only way I can see this coming up is in error.

To verify that a running job only has access to one GPU, you can use the CUDA_VISIBLE_DEVICES environment variable. This environment variable reports the indices for the GPU devices available, in a format like '0,1,2,3', which would indicate that the job has access to 4 GPUs with indices 0, 1, 2, and 3. This allows you to confirm the number of GPUs accessible to the job, based on the number of indices in the variable, and the actual GPUs used by the job. This can confirm that 4 different GPU jobs are in fact allocated 4 different GPUs, and not the same GPU 4 times.

In the torch library, it's also possible to confirm that the job only has access to one GPU. Attempting to run torch.cuda.set_device(1) when multiple GPUs are available will complete without error. However, when only one GPU is available, the command fails with a RuntimeError: CUDA error: invalid device ordinal.

I tried manually setting the CUDA_VISIBLE_DEVICES variable to try to get more GPUs, but the torch command to use another device still failed. I'm not sure why this is the case, but it seems like there's something else happening preventing access to the other GPUs. Possibly something happening in Slurm.